### PR TITLE
Replace RuleRegistry with RuleSet and unify rule model (#102)

### DIFF
--- a/demo/client/harmonize_example_client.ts
+++ b/demo/client/harmonize_example_client.ts
@@ -52,14 +52,6 @@ async function main() {
     rules_file_path: rulesFilePath,
     replay_log_file_path: replayLogFilePath,
     output_file_path: outputFilePath,
-    mode: "pairs",
-    pairs: [
-      { source: "age", target: "age_years" },
-      { source: "weight_lbs", target: "weight_kg" },
-      { source: "name", target: "given_name" },
-      { source: "name", target: "family_name" },
-      { source: "visit_type_code", target: "visit_type_label" },
-    ],
     overwrite: true,
   };
 

--- a/demo/client/rpc_types.ts
+++ b/demo/client/rpc_types.ts
@@ -11,19 +11,18 @@ export type JobStatus = (typeof JOB_STATUS)[keyof typeof JOB_STATUS];
 
 
 // Params accepted by the harmonize RPC method.
+//
+// Every rule in the rules file is applied. To run a subset, supply a
+// rules file containing only the desired targets.
 export interface HarmonizeRequest {
   // Absolute path to the input CSV file.
   data_file_path: string;
-  // Absolute path to the rules JSON file (RuleRegistry.save()).
+  // Absolute path to the rules JSON file (RuleSet.save()).
   rules_file_path: string;
   // Absolute path where the replay log should be written.
   replay_log_file_path: string;
   // Absolute path where the output CSV should be written.
   output_file_path: string;
-  // "pairs" applies only the specified pairs; "all" uses all rules in the registry.
-  mode: "pairs" | "all";
-  // Explicit list of (source, target) pairs to harmonize.
-  pairs?: Array<{ source: string; target: string }>;
   // Overwrite output and replay log files if they already exist.
   overwrite?: boolean;
 }

--- a/demo/harmonize_example/output.csv
+++ b/demo/harmonize_example/output.csv
@@ -1,4 +1,4 @@
-given_name,family_name,age_years,weight_kg,visit_type_label,source dataset,original_id
-Alice,Smith,10,35.50,baseline,demo,0
-Bob,Jones,5,20.18,follow_up,demo,1
-Carol,Nguyen,8,41.82,screening,demo,2
+given_name,family_name,age_years,weight_kg,visit_type_label,source dataset,original_id,age,weight_lbs,name,visit_type_code
+Alice,Smith,10,35.50,baseline,demo,0,10,78.26,"Smith, Alice",BL
+Bob,Jones,5,20.18,follow_up,demo,1,5,44.5,"Jones, Bob",FU
+Carol,Nguyen,8,41.82,screening,demo,2,8,92.2,"Nguyen, Carol",SC

--- a/demo/harmonize_example/rules.json
+++ b/demo/harmonize_example/rules.json
@@ -1,75 +1,67 @@
-{
-  "age": {
-    "age_years": {
-      "source": "age",
-      "target": "age_years",
-      "operations": []
-    }
+[
+  {
+    "sources": ["age"],
+    "target": "age_years",
+    "operations": []
   },
-  "weight_lbs": {
-    "weight_kg": {
-      "source": "weight_lbs",
-      "target": "weight_kg",
-      "operations": [
-        {
-          "operation": "scale",
-          "scaling_factor": 0.453592
-        },
-        {
-          "operation": "format_number",
-          "precision": 2
-        }
-      ]
-    }
+  {
+    "sources": ["weight_lbs"],
+    "target": "weight_kg",
+    "operations": [
+      {
+        "operation": "scale",
+        "scaling_factor": 0.453592
+      },
+      {
+        "operation": "format_number",
+        "precision": 2
+      }
+    ]
   },
-  "name": {
-    "given_name": {
-      "source": "name",
-      "target": "given_name",
-      "operations": [
-        {
-          "operation": "substitute",
-          "expression": "^\\s*([^,]+),\\s*(.+)$",
-          "substitution": "\\2"
-        },
-        {
-          "operation": "normalize_text",
-          "normalization": "strip"
-        }
-      ]
-    },
-    "family_name": {
-      "source": "name",
-      "target": "family_name",
-      "operations": [
-        {
-          "operation": "substitute",
-          "expression": "^\\s*([^,]+),\\s*(.+)$",
-          "substitution": "\\1"
-        },
-        {
-          "operation": "normalize_text",
-          "normalization": "strip"
-        }
-      ]
-    }
+  {
+    "sources": ["name"],
+    "target": "given_name",
+    "operations": [
+      {
+        "operation": "substitute",
+        "expression": "^\\s*([^,]+),\\s*(.+)$",
+        "substitution": "\\2"
+      },
+      {
+        "operation": "normalize_text",
+        "normalization": "strip"
+      }
+    ]
   },
-  "visit_type_code": {
-    "visit_type_label": {
-      "source": "visit_type_code",
-      "target": "visit_type_label",
-      "operations": [
-        {
-          "operation": "enum_to_enum",
-          "mapping": {
-            "BL": "baseline",
-            "FU": "follow_up",
-            "SC": "screening"
-          },
-          "default": "unknown",
-          "strict": false
-        }
-      ]
-    }
+  {
+    "sources": ["name"],
+    "target": "family_name",
+    "operations": [
+      {
+        "operation": "substitute",
+        "expression": "^\\s*([^,]+),\\s*(.+)$",
+        "substitution": "\\1"
+      },
+      {
+        "operation": "normalize_text",
+        "normalization": "strip"
+      }
+    ]
+  },
+  {
+    "sources": ["visit_type_code"],
+    "target": "visit_type_label",
+    "operations": [
+      {
+        "operation": "enum_to_enum",
+        "mapping": {
+          "BL": "baseline",
+          "FU": "follow_up",
+          "SC": "screening"
+        },
+        "default": "unknown",
+        "strict": false
+      }
+    ]
   }
-}
+]

--- a/demo/harmonize_example/run_example.py
+++ b/demo/harmonize_example/run_example.py
@@ -6,7 +6,7 @@ from pathlib import Path
 # understand the minimal steps required to use the framework.
 
 from harmonization_framework.harmonize import harmonize_file
-from harmonization_framework.rule_registry import RuleRegistry
+from harmonization_framework.rule_registry import RuleSet
 
 
 def main() -> None:
@@ -22,30 +22,19 @@ def main() -> None:
     output_path = base_dir / "output.csv"
     print("output_path: ", output_path)
 
-    # The RuleRegistry is the in-memory container for all harmonization rules.
-    # Loading the JSON file builds a registry of source/target rules that
-    # harmonize values from the source column into the target column.
-    rules = RuleRegistry()
+    # The RuleSet is the in-memory container for all harmonization rules.
+    # Loading the JSON file builds a flat collection of rules; each rule
+    # declares its source columns and the target column it produces.
+    rules = RuleSet()
     rules.load(str(rules_path), clean=True)
 
-    # Each pair is (source_column, target_column). These names must match
-    # the rules in rules.json. The framework will:
-    # 1) rename the column to the target name
-    # 2) apply the rule for that source/target to each value
-    harmonization_pairs = [
-        ("age", "age_years"),
-        ("weight_lbs", "weight_kg"),
-        ("name", "given_name"),
-        ("name", "family_name"),
-        ("visit_type_code", "visit_type_label"),
-    ]
-
-    # Run the harmonization and save the output CSV.
+    # Run the harmonization and save the output CSV. Every rule in the
+    # RuleSet is applied; to run a subset, build a RuleSet that contains
+    # only the rules you want.
     # dataset_name becomes the value of the "source dataset" column.
     harmonized = harmonize_file(
         input_path=str(input_path),
         output_path=str(output_path),
-        harmonization_pairs=harmonization_pairs,
         rules=rules,
         dataset_name="demo",
     )

--- a/demo/primitives_ui/rules.json
+++ b/demo/primitives_ui/rules.json
@@ -1,219 +1,187 @@
-{
-  "age_years": {
-    "age_group": {
-      "source": "age_years",
-      "target": "age_group",
-      "operations": [
-        {
-          "operation": "bin",
-          "bins": [
-            {"label": 1, "start": 0, "end": 12},
-            {"label": 2, "start": 13, "end": 17},
-            {"label": 3, "start": 18, "end": 64},
-            {"label": 4, "start": 65, "end": 120}
-          ]
-        }
-      ]
-    }
+[
+  {
+    "sources": ["age_years"],
+    "target": "age_group",
+    "operations": [
+      {
+        "operation": "bin",
+        "bins": [
+          {"label": 1, "start": 0, "end": 12},
+          {"label": 2, "start": 13, "end": 17},
+          {"label": 3, "start": 18, "end": 64},
+          {"label": 4, "start": 65, "end": 120}
+        ]
+      }
+    ]
   },
-  "age_group": {
-    "age_group_label": {
-      "source": "age_group",
-      "target": "age_group_label",
-      "operations": [
-        {
-          "operation": "enum_to_enum",
-          "mapping": {
-            "1": "child",
-            "2": "teen",
-            "3": "adult",
-            "4": "senior"
-          },
-          "default": "unknown",
-          "strict": false
-        }
-      ]
-    }
-  },
-  "zip_code_text": {
-    "zip_code": {
-      "source": "zip_code_text",
-      "target": "zip_code",
-      "operations": [
-        {
-          "operation": "cast",
-          "source": "text",
-          "target": "integer"
-        }
-      ]
-    }
-  },
-  "visit_date_iso": {
-    "visit_date_us": {
-      "source": "visit_date_iso",
-      "target": "visit_date_us",
-      "operations": [
-        {
-          "operation": "convert_date",
-          "source_format": "%Y-%m-%d",
-          "target_format": "%m/%d/%Y"
-        }
-      ]
-    }
-  },
-  "weight_kg": {
-    "weight_lb": {
-      "source": "weight_kg",
-      "target": "weight_lb",
-      "operations": [
-        {
-          "operation": "convert_units",
-          "source_unit": "kg",
-          "target_unit": "lb"
-        }
-      ]
-    }
-  },
-  "record_id": {
-    "record_id_copy": {
-      "source": "record_id",
-      "target": "record_id_copy",
-      "operations": [
-        {
-          "operation": "do_nothing"
-        }
-      ]
-    }
-  },
-  "bmi": {
-    "bmi_formatted": {
-      "source": "bmi",
-      "target": "bmi_formatted",
-      "operations": [
-        {
-          "operation": "format_number",
-          "precision": 1
-        }
-      ]
-    }
-  },
-  "smoker_response": {
-    "is_smoker": {
-      "source": "smoker_response",
-      "target": "is_smoker",
-      "operations": [
-        {
-          "operation": "normalize_boolean",
-          "truthy": ["true", "t", "yes", "y", "1", 1, true, "on"],
-          "falsy": ["false", "f", "no", "n", "0", 0, false, "off", ""],
-          "strict": false,
-          "default": null
-        }
-      ]
-    }
-  },
-  "city_raw": {
-    "city_normalized": {
-      "source": "city_raw",
-      "target": "city_normalized",
-      "operations": [
-        {
-          "operation": "normalize_text",
-          "normalization": "lower"
-        }
-      ]
-    }
-  },
-  "thermometer_c": {
-    "calibrated_c": {
-      "source": "thermometer_c",
-      "target": "calibrated_c",
-      "operations": [
-        {
-          "operation": "offset",
-          "offset": 0.5
-        }
-      ]
-    }
-  },
-  "week_hours": {
-    "total_hours": {
-      "source": "week_hours",
-      "target": "total_hours",
-      "operations": [
-        {
-          "operation": "parse_array",
-          "format": "json",
-          "item_type": "integer",
-          "strict": true
+  {
+    "sources": ["age_group"],
+    "target": "age_group_label",
+    "operations": [
+      {
+        "operation": "enum_to_enum",
+        "mapping": {
+          "1": "child",
+          "2": "teen",
+          "3": "adult",
+          "4": "senior"
         },
-        {
-          "operation": "reduce",
-          "reduction": "sum"
-        }
-      ]
-    }
+        "default": "unknown",
+        "strict": false
+      }
+    ]
   },
-  "medication_dose_mg": {
-    "medication_dose_mg_rounded": {
-      "source": "medication_dose_mg",
-      "target": "medication_dose_mg_rounded",
-      "operations": [
-        {
-          "operation": "round",
-          "precision": 2
-        }
-      ]
-    }
+  {
+    "sources": ["zip_code_text"],
+    "target": "zip_code",
+    "operations": [
+      {
+        "operation": "cast",
+        "source": "text",
+        "target": "integer"
+      }
+    ]
   },
-  "price_usd": {
-    "price_cents": {
-      "source": "price_usd",
-      "target": "price_cents",
-      "operations": [
-        {
-          "operation": "scale",
-          "scaling_factor": 100
-        }
-      ]
-    }
+  {
+    "sources": ["visit_date_iso"],
+    "target": "visit_date_us",
+    "operations": [
+      {
+        "operation": "convert_date",
+        "source_format": "%Y-%m-%d",
+        "target_format": "%m/%d/%Y"
+      }
+    ]
   },
-  "name_last_first": {
-    "name_first_last": {
-      "source": "name_last_first",
-      "target": "name_first_last",
-      "operations": [
-        {
-          "operation": "substitute",
-          "expression": "^\\s*([^,]+),\\s*(.+)$",
-          "substitution": "\\2 \\1"
-        }
-      ]
-    }
+  {
+    "sources": ["weight_kg"],
+    "target": "weight_lb",
+    "operations": [
+      {
+        "operation": "convert_units",
+        "source_unit": "kg",
+        "target_unit": "lb"
+      }
+    ]
   },
-  "pulse_rate": {
-    "pulse_rate_clamped": {
-      "source": "pulse_rate",
-      "target": "pulse_rate_clamped",
-      "operations": [
-        {
-          "operation": "threshold",
-          "lower": 40,
-          "upper": 200
-        }
-      ]
-    }
+  {
+    "sources": ["record_id"],
+    "target": "record_id_copy",
+    "operations": [
+      {
+        "operation": "do_nothing"
+      }
+    ]
   },
-  "username": {
-    "username_short": {
-      "source": "username",
-      "target": "username_short",
-      "operations": [
-        {
-          "operation": "truncate",
-          "length": 8
-        }
-      ]
-    }
+  {
+    "sources": ["bmi"],
+    "target": "bmi_formatted",
+    "operations": [
+      {
+        "operation": "format_number",
+        "precision": 1
+      }
+    ]
+  },
+  {
+    "sources": ["smoker_response"],
+    "target": "is_smoker",
+    "operations": [
+      {
+        "operation": "normalize_boolean",
+        "truthy": ["true", "t", "yes", "y", "1", 1, true, "on"],
+        "falsy": ["false", "f", "no", "n", "0", 0, false, "off", ""],
+        "strict": false,
+        "default": null
+      }
+    ]
+  },
+  {
+    "sources": ["city_raw"],
+    "target": "city_normalized",
+    "operations": [
+      {
+        "operation": "normalize_text",
+        "normalization": "lower"
+      }
+    ]
+  },
+  {
+    "sources": ["thermometer_c"],
+    "target": "calibrated_c",
+    "operations": [
+      {
+        "operation": "offset",
+        "offset": 0.5
+      }
+    ]
+  },
+  {
+    "sources": ["week_hours"],
+    "target": "total_hours",
+    "operations": [
+      {
+        "operation": "parse_array",
+        "format": "json",
+        "item_type": "integer",
+        "strict": true
+      },
+      {
+        "operation": "reduce",
+        "reduction": "sum"
+      }
+    ]
+  },
+  {
+    "sources": ["medication_dose_mg"],
+    "target": "medication_dose_mg_rounded",
+    "operations": [
+      {
+        "operation": "round",
+        "precision": 2
+      }
+    ]
+  },
+  {
+    "sources": ["price_usd"],
+    "target": "price_cents",
+    "operations": [
+      {
+        "operation": "scale",
+        "scaling_factor": 100
+      }
+    ]
+  },
+  {
+    "sources": ["name_last_first"],
+    "target": "name_first_last",
+    "operations": [
+      {
+        "operation": "substitute",
+        "expression": "^\\s*([^,]+),\\s*(.+)$",
+        "substitution": "\\2 \\1"
+      }
+    ]
+  },
+  {
+    "sources": ["pulse_rate"],
+    "target": "pulse_rate_clamped",
+    "operations": [
+      {
+        "operation": "threshold",
+        "lower": 40,
+        "upper": 200
+      }
+    ]
+  },
+  {
+    "sources": ["username"],
+    "target": "username_short",
+    "operations": [
+      {
+        "operation": "truncate",
+        "length": 8
+      }
+    ]
   }
-}
+]

--- a/src/harmonization_framework/__init__.py
+++ b/src/harmonization_framework/__init__.py
@@ -1,2 +1,3 @@
-from .harmonize import harmonize_dataset, harmonize_file
 from .harmonization_rule import HarmonizationRule
+from .harmonize import harmonize_dataset, harmonize_file
+from .rule_registry import RuleSet

--- a/src/harmonization_framework/api/routes/rpc.py
+++ b/src/harmonization_framework/api/routes/rpc.py
@@ -45,12 +45,13 @@ def rpc_call(request: RpcRequest) -> RpcResponse:
     - harmonize:
         params:
           data_file_path: absolute path to input CSV
-          rules_file_path: absolute path to RuleRegistry JSON
+          rules_file_path: absolute path to RuleSet JSON
           replay_log_file_path: absolute path to write replay log
           output_file_path: absolute path to write harmonized CSV
-          mode: "pairs" | "all"
-          pairs: optional list of {source, target} when mode="pairs"
           overwrite: boolean (default false)
+
+        All rules in the rules file are applied. To run a subset, supply a
+        rules file containing only the desired targets.
 
         response:
           status: "accepted"

--- a/src/harmonization_framework/api/rpc_handlers.py
+++ b/src/harmonization_framework/api/rpc_handlers.py
@@ -1,13 +1,13 @@
 import os
 import threading
 import uuid
-from typing import Dict, List, Optional, Tuple
+from typing import Optional, Tuple
 
 import pandas as pd
 
 from harmonization_framework.harmonize import harmonize_dataset
 from harmonization_framework.replay_log import replay_logger as rlog
-from harmonization_framework.rule_registry import RuleRegistry
+from harmonization_framework.rule_registry import RuleSet
 from harmonization_framework.api.rpc_errors import ErrorCode, build_error
 from harmonization_framework.api.rpc_jobs import (
     JobId,
@@ -66,55 +66,20 @@ def _validate_paths(params: HarmonizeParams) -> Optional[RpcResponse]:
     return None
 
 
-def _load_rules(params: HarmonizeParams) -> Tuple[Optional[RuleRegistry], Optional[RpcResponse]]:
-    """Load a RuleRegistry from a rules JSON file."""
-    registry = RuleRegistry()
+def _load_rules(params: HarmonizeParams) -> Tuple[Optional[RuleSet], Optional[RpcResponse]]:
+    """Load a RuleSet from a rules JSON file."""
+    rules = RuleSet()
     try:
-        registry.load(params.rules_file_path, clean=True)
+        rules.load(params.rules_file_path, clean=True)
     except Exception as exc:
         return None, build_error(ErrorCode.INVALID_FORMAT, f"Failed to load rules: {exc}")
-    return registry, None
-
-
-def _resolve_harmonization_pairs(
-    params: HarmonizeParams, registry: RuleRegistry
-) -> Tuple[Optional[List[Tuple[str, str]]], Optional[RpcResponse]]:
-    """
-    Resolve requested (source, target) pairs based on mode and availability.
-
-    - mode="all": return all pairs from the rules registry (error if empty).
-    - mode="pairs": validate that requested pairs exist in the registry.
-
-    Returns (pairs, error). On error, pairs is None and error is a RpcResponse.
-    """
-    if params.mode == "all":
-        pairs = registry.list_pairs()
-        if not pairs:
-            return None, build_error(
-                ErrorCode.RULE_NOT_FOUND,
-                "No rules found in rules file",
-                details={"path": params.rules_file_path},
-            )
-        return pairs, None
-
-    if not params.harmonization_pairs:
+    if len(rules) == 0:
         return None, build_error(
-            ErrorCode.MISSING_FIELD,
-            "pairs is required when mode is 'pairs'",
-            details={"field": "pairs"},
+            ErrorCode.RULE_NOT_FOUND,
+            "No rules found in rules file",
+            details={"path": params.rules_file_path},
         )
-
-    pairs = [(pair.source, pair.target) for pair in params.harmonization_pairs]
-    for source, target in pairs:
-        try:
-            registry.query(source, target)
-        except Exception:
-            return None, build_error(
-                ErrorCode.RULE_NOT_FOUND,
-                f"Rule not found for source={source} target={target}",
-                details={"source": source, "target": target},
-            )
-    return pairs, None
+    return rules, None
 
 
 def _run_harmonize(job_id: JobId, params: HarmonizeParams) -> None:
@@ -123,11 +88,10 @@ def _run_harmonize(job_id: JobId, params: HarmonizeParams) -> None:
 
     Workflow:
     1) Validate paths and overwrite behavior.
-    2) Load rules from the registry JSON file.
-    3) Resolve rule pairs based on the requested mode.
-    4) Create output/log directories as needed.
-    5) Read input CSV, apply harmonization with row-based progress callbacks.
-    6) Write output CSV and finalize job state.
+    2) Load rules from the rule set JSON file.
+    3) Create output/log directories as needed.
+    4) Read input CSV, apply harmonization with row-based progress callbacks.
+    5) Write output CSV and finalize job state.
 
     On failure, sets job status to "failed" and records a structured error.
     """
@@ -138,12 +102,7 @@ def _run_harmonize(job_id: JobId, params: HarmonizeParams) -> None:
         update_job_status(job_id, status="failed", error=validation_error.error.model_dump())
         return
 
-    registry, error = _load_rules(params)
-    if error:
-        update_job_status(job_id, status="failed", error=error.error.model_dump())
-        return
-
-    pairs, error = _resolve_harmonization_pairs(params, registry)
+    rules, error = _load_rules(params)
     if error:
         update_job_status(job_id, status="failed", error=error.error.model_dump())
         return
@@ -160,8 +119,7 @@ def _run_harmonize(job_id: JobId, params: HarmonizeParams) -> None:
     try:
         harmonized = harmonize_dataset(
             dataset=dataset,
-            harmonization_pairs=pairs,
-            rules=registry,
+            rules=rules,
             dataset_name=os.path.basename(params.data_file_path),
             logger=logger,
             progress_callback=progress_callback,

--- a/src/harmonization_framework/api/rpc_models.py
+++ b/src/harmonization_framework/api/rpc_models.py
@@ -1,12 +1,6 @@
-from typing import Dict, List, Literal, Optional
+from typing import Dict, Optional
 
-from pydantic import BaseModel, ConfigDict, Field
-
-
-class HarmonizationPair(BaseModel):
-    """Source/target column pair."""
-    source: str = Field(..., description="Source column name")
-    target: str = Field(..., description="Target column name")
+from pydantic import BaseModel, ConfigDict
 
 
 class HarmonizeParams(BaseModel):
@@ -15,25 +9,20 @@ class HarmonizeParams(BaseModel):
 
     Required:
         data_file_path: absolute path to the input CSV file.
-        rules_file_path: absolute path to a RuleRegistry JSON file.
+        rules_file_path: absolute path to a RuleSet JSON file.
         replay_log_file_path: absolute path for the replay log output.
         output_file_path: absolute path for the harmonized CSV output.
-        mode: "pairs" to apply a specific subset of rules, or "all" to apply all rules.
 
     Optional:
-        harmonization_pairs: list of source/target column mappings (required when mode="pairs").
         overwrite: when True, allows output_path to be overwritten if it already exists.
+
+    All rules in the rules file are applied. To restrict which rules run,
+    construct a rules file containing only the desired targets.
     """
     data_file_path: str
     rules_file_path: str
     replay_log_file_path: str
     output_file_path: str
-    mode: Literal["pairs", "all"]
-    harmonization_pairs: Optional[List[HarmonizationPair]] = Field(
-        None,
-        alias="pairs",
-        description="List of (source, target) column mappings when mode='pairs'.",
-    )
     overwrite: bool = False
 
     model_config = ConfigDict(populate_by_name=True)

--- a/src/harmonization_framework/cli.py
+++ b/src/harmonization_framework/cli.py
@@ -1,12 +1,12 @@
 import argparse
 import os
-import sys
-from typing import Iterable, List, Sequence, Tuple
+from typing import Iterable, List, Sequence
 
 import pandas as pd
 
 from .harmonize import harmonize_dataset
-from .rule_registry import RuleRegistry
+from .harmonization_rule import HarmonizationRule
+from .rule_registry import RuleSet
 
 
 def _split_list(values: Sequence[str]) -> List[str]:
@@ -23,61 +23,66 @@ def _split_list(values: Sequence[str]) -> List[str]:
 
 
 def _read_table(path: str) -> pd.DataFrame:
-    # Autodetect delimiter based on file extension.
     _, ext = os.path.splitext(path.lower())
     sep = "\t" if ext in {".tsv", ".tab"} else ","
     return pd.read_csv(path, sep=sep)
 
 
 def _write_table(df: pd.DataFrame, path: str) -> None:
-    # Use the same delimiter heuristics as the reader for output.
     _, ext = os.path.splitext(path.lower())
     sep = "\t" if ext in {".tsv", ".tab"} else ","
     df.to_csv(path, index=False, sep=sep)
 
 
-def _load_rules(rule_paths: Iterable[str]) -> RuleRegistry:
-    # Merge multiple rules files into a single registry.
-    registry = RuleRegistry()
+def _load_rules(rule_paths: Iterable[str]) -> RuleSet:
+    # Merge multiple rules files into a single rule set.
+    rules = RuleSet()
     first = True
     for path in rule_paths:
-        registry.load(path, clean=first)
+        rules.load(path, clean=first)
         first = False
-    return registry
+    return rules
 
 
-def _select_pairs(
-    all_pairs: List[Tuple[str, str]],
-    targets: List[str],
-) -> List[Tuple[str, str]]:
-    # Filter rule pairs by requested targets when provided.
+def _filter_to_targets(rules: RuleSet, targets: List[str]) -> RuleSet:
+    # Apply --targets as a load-time filter on the rule set itself.
     if not targets:
-        return all_pairs
-    target_set = set(targets)
-    return [(source, target) for source, target in all_pairs if target in target_set]
+        return rules
+    filtered = RuleSet()
+    for rule in rules.for_targets(targets):
+        filtered.add_rule(rule)
+    return filtered
 
 
-def _filter_missing(
-    pairs: List[Tuple[str, str]],
+def _filter_missing_sources(
+    rules: RuleSet,
     columns: Iterable[str],
     on_missing: str,
-) -> List[Tuple[str, str]]:
-    # Enforce missing-source behavior: error, warn+skip, or skip.
+) -> RuleSet:
+    # Enforce missing-source behavior: error, warn+skip, or skip. A rule is
+    # considered missing if any of its source columns is absent.
     column_set = set(columns)
-    missing = [pair for pair in pairs if pair[0] not in column_set]
-    if not missing:
-        return pairs
+    missing_rules: List[HarmonizationRule] = []
+    kept_rules: List[HarmonizationRule] = []
+    for rule in rules.all_rules():
+        if all(source in column_set for source in rule.sources):
+            kept_rules.append(rule)
+        else:
+            missing_rules.append(rule)
 
-    if on_missing == "error":
-        missing_sources = ", ".join(sorted({source for source, _ in missing}))
-        raise ValueError(f"Missing source columns: {missing_sources}")
+    if missing_rules:
+        missing_sources = sorted(
+            {source for rule in missing_rules for source in rule.sources if source not in column_set}
+        )
+        if on_missing == "error":
+            raise ValueError(f"Missing source columns: {', '.join(missing_sources)}")
+        if on_missing == "warn":
+            print(f"Warning: skipping missing source columns: {', '.join(missing_sources)}")
 
-    if on_missing == "warn":
-        missing_sources = ", ".join(sorted({source for source, _ in missing}))
-        print(f"Warning: skipping missing source columns: {missing_sources}")
-
-    # skip missing when warn or skip
-    return [pair for pair in pairs if pair[0] in column_set]
+    filtered = RuleSet()
+    for rule in kept_rules:
+        filtered.add_rule(rule)
+    return filtered
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -123,9 +128,7 @@ def main(argv: Sequence[str] | None = None) -> None:
     args = parser.parse_args(argv)
 
     try:
-        # Load and merge all rule files into one registry.
         rules = _load_rules(args.rules)
-        # Read the input dataset (CSV/TSV).
         dataset = _read_table(args.input)
     except FileNotFoundError as exc:
         parser.error(f"{exc.filename} not found.")
@@ -134,33 +137,29 @@ def main(argv: Sequence[str] | None = None) -> None:
         parser.error(str(exc))
         return
 
-    # Determine which targets to generate.
+    # Filter the rule set to requested targets before harmonization.
     targets = _split_list(args.targets)
-    pairs = _select_pairs(rules.list_pairs(), targets)
-    if not pairs:
-        parser.error("No harmonization pairs selected. Check --targets or rules.")
+    rules = _filter_to_targets(rules, targets)
+    if len(rules) == 0:
+        parser.error("No harmonization rules selected. Check --targets or rules.")
         return
 
-    # Drop or error on missing source columns based on CLI flag.
     try:
-        pairs = _filter_missing(pairs, dataset.columns, args.on_missing)
+        rules = _filter_missing_sources(rules, dataset.columns, args.on_missing)
     except ValueError as exc:
         parser.error(str(exc))
         return
-    if not pairs:
-        parser.error("No harmonization pairs available after filtering missing columns.")
+    if len(rules) == 0:
+        parser.error("No harmonization rules available after filtering missing columns.")
         return
 
-    # Default dataset name mirrors input filename if not explicitly set.
     dataset_name = args.dataset_name
     if dataset_name is None:
         dataset_name = os.path.basename(args.input)
 
-    # Apply harmonization.
     try:
         harmonized = harmonize_dataset(
             dataset=dataset,
-            harmonization_pairs=pairs,
             rules=rules,
             dataset_name=dataset_name,
             logger=None,
@@ -169,13 +168,11 @@ def main(argv: Sequence[str] | None = None) -> None:
         parser.error(f"Failed to harmonize: {exc}")
         return
 
-    # Emit only target columns by default, optionally include metadata.
-    target_columns = [target for _, target in pairs]
+    target_columns = rules.all_targets()
     if args.include_metadata:
-        target_columns += ["source dataset", "original_id"]
+        target_columns = target_columns + ["source dataset", "original_id"]
     harmonized = harmonized[target_columns]
 
-    # Persist output with delimiter matched to file extension.
     _write_table(harmonized, args.output)
 
 

--- a/src/harmonization_framework/harmonization_rule.py
+++ b/src/harmonization_framework/harmonization_rule.py
@@ -1,21 +1,19 @@
 from typing import Any, Dict, List, Optional
-from .element import DataElement
 from .primitives.base import PrimitiveOperation
 from .primitives import PrimitiveVocabulary, Bin, Cast, ConvertDate, ConvertUnits, DoNothing, EnumToEnum, FormatNumber, NormalizeBoolean, NormalizeText, Offset, ParseArray, Reduce, Round, Scale, Substitute, Threshold, Truncate
 
 import json
 
-# Backwards-compatible alias
 
 class HarmonizationRule:
     def __init__(
         self,
-        source: DataElement,
-        target: DataElement,
-        transformation: List[PrimitiveOperation] = None,
+        sources: List[str],
+        target: str,
+        transformation: Optional[List[PrimitiveOperation]] = None,
         metadata: Optional[Dict[str, Any]] = None,
     ):
-        self.source = source
+        self.sources = list(sources) if sources is not None else []
         self.target = target
         self._transform = transformation
         self.metadata = metadata
@@ -23,7 +21,7 @@ class HarmonizationRule:
 
     def serialize(self):
         output = {
-            "source": f"{self.source}",
+            "sources": list(self.sources),
             "target": f"{self.target}",
             "operations": [
                 primitive.to_dict() for primitive in (self._transform or [])
@@ -35,15 +33,24 @@ class HarmonizationRule:
 
     def __str__(self):
         text = []
-        for i, transform in enumerate(self._transform):
+        for i, transform in enumerate(self._transform or []):
             text.append(f"Harmonization Operation {i+1}:")
             text.append(str(transform))
         return "\n".join(text)
-    
-    def transform(self, value: Any) -> Any:
+
+    def transform(self, values: Any) -> Any:
         """
         Apply transformation primitives in serial.
+
+        Accepts either a scalar (single-source rule called directly) or a list
+        of values (one per entry in `sources`). Single-source rules unwrap the
+        singleton before passing it to the operations chain so existing
+        primitives continue to receive a scalar.
         """
+        if isinstance(values, list):
+            value = values[0] if len(self.sources) == 1 else values
+        else:
+            value = values
         if self._transform is None:
             return value
         for transform in self._transform:
@@ -52,7 +59,11 @@ class HarmonizationRule:
 
     @classmethod
     def from_serialization(cls, serialization):
-        source = serialization["source"]
+        # Accept both new "sources": [...] schema and legacy "source": "..." key.
+        if "sources" in serialization:
+            sources = list(serialization["sources"])
+        else:
+            sources = [serialization["source"]]
         target = serialization["target"]
         operations = serialization["operations"]
         metadata = serialization.get("metadata")
@@ -96,8 +107,4 @@ class HarmonizationRule:
                 case _:
                     raise ValueError(f"Unknown operation: {operation['operation']}")
             transformation.append(primitive)
-        return HarmonizationRule(source, target, transformation, metadata=metadata)
-
-
-# Backwards-compatible alias
-Rule = HarmonizationRule
+        return HarmonizationRule(sources, target, transformation, metadata=metadata)

--- a/src/harmonization_framework/harmonize.py
+++ b/src/harmonization_framework/harmonize.py
@@ -1,67 +1,62 @@
 import os
 import pandas as pd
 
-from typing import Callable, List, Optional, Tuple
+from typing import Callable, Optional
 
-from .rule_registry import RuleRegistry
+from .rule_registry import RuleSet
 from .replay_log import replay_logger as rlog
 
 
 def harmonize_dataset(
     dataset: pd.DataFrame,
-    harmonization_pairs: List[Tuple[str]],
-    rules: RuleRegistry,
+    rules: RuleSet,
     dataset_name: str,
     logger=None,
     progress_callback: Optional[Callable[[int, int], None]] = None,
 ) -> pd.DataFrame:
     """
-    Apply harmonization rules to the provided dataset and return a new dataframe.
+    Apply every rule in the rule set to the provided dataset and return a new dataframe.
 
-    This function:
-    - Renames columns based on the provided source/target pairs.
-    - Applies the corresponding harmonization rule to each source column.
-    - Appends `source dataset` and `original_id` metadata columns.
+    For each rule, the columns named in `rule.sources` are read from the dataset
+    and passed (as a list, one element per source) to `rule.transform`. The
+    result is written to a new column named `rule.target`. Single-source rules
+    transparently unwrap to a scalar inside `transform`.
+
+    The output dataframe contains every column from the input plus the produced
+    target columns, along with `source dataset` and `original_id` metadata
+    columns.
 
     Args:
-        dataset: Source dataframe containing the original columns.
-        harmonization_pairs: List of (source, target) column name pairs.
-        rules: RuleRegistry with harmonization rules keyed by source/target.
+        dataset: Source dataframe.
+        rules: RuleSet whose rules will all be applied.
         dataset_name: Name used for the `source dataset` metadata column.
         logger: Optional replay logger for recording applied rules.
         progress_callback: Optional callback invoked with (processed, total) counts.
     """
-    # make a new dataframe with the same number of rows and columns
-    # and rename the columns
     dataset_harmonized = dataset.copy()
-    dataset_harmonized.rename(
-        columns={source: target for source, target in harmonization_pairs},
-        inplace=True,
-    )
-    # apply harmonization rule to each column
-    total_steps = len(dataset) * len(harmonization_pairs) if harmonization_pairs else 0
+
+    rules_list = rules.all_rules()
+    total_steps = len(dataset) * len(rules_list) if rules_list else 0
     processed = 0
 
-    for source, target in harmonization_pairs:
-        print(f"Requested rule: {source} -> {target}")
-        rule = rules.query(source, target)
-        # record action in replay logger
+    for rule in rules_list:
+        print(f"Applying rule -> {rule.target} (sources: {rule.sources})")
         if logger:
             rlog.log_operation(logger, rule, dataset_name)
-        dataset_harmonized.rename(columns={source: target}, inplace=True)
 
-        def transform_with_progress(value):
+        def transform_with_progress(row, _rule=rule):
             nonlocal processed
-            result = rule.transform(value)
+            result = _rule.transform(row.tolist())
             processed += 1
             if progress_callback:
                 progress_callback(processed, total_steps)
             return result
 
-        dataset_harmonized[target] = dataset[source].apply(transform_with_progress)
-    # save source dataset
+        dataset_harmonized[rule.target] = dataset[rule.sources].apply(
+            transform_with_progress, axis=1
+        )
+
     dataset_harmonized["source dataset"] = [dataset_name] * len(dataset)
-    # save old ids
     dataset_harmonized["original_id"] = dataset.index.to_list()
     return dataset_harmonized
 
@@ -69,34 +64,22 @@ def harmonize_dataset(
 def harmonize_file(
     input_path: str,
     output_path: str,
-    harmonization_pairs: List[Tuple[str, str]],
-    rules: RuleRegistry,
+    rules: RuleSet,
     dataset_name: Optional[str] = None,
     logger=None,
 ) -> pd.DataFrame:
     """
     Load a CSV file, apply harmonization, and save the result to disk.
-
-    Args:
-        input_path: Path to the input CSV.
-        output_path: Path where the harmonized CSV will be written.
-        harmonization_pairs: List of (source, target) column name pairs.
-        rules: RuleRegistry with harmonization rules keyed by source/target.
-        dataset_name: Optional label used for the `source dataset` column.
-        logger: Optional replay logger for recording applied rules.
     """
     if dataset_name is None:
         dataset_name = os.path.basename(input_path)
 
-    # Load the input dataset and apply harmonization rules.
     dataset = pd.read_csv(input_path)
     harmonized = harmonize_dataset(
         dataset=dataset,
-        harmonization_pairs=harmonization_pairs,
         rules=rules,
         dataset_name=dataset_name,
         logger=logger,
     )
-    # Persist the output to disk.
     harmonized.to_csv(output_path, index=False)
     return harmonized

--- a/src/harmonization_framework/rule_registry.py
+++ b/src/harmonization_framework/rule_registry.py
@@ -1,86 +1,101 @@
+from typing import Iterable, List
+
 from .harmonization_rule import HarmonizationRule
-from .primitives import DoNothing
 
 import json
 
-class RuleRegistry:
-    """
-    In-memory storage for harmonization rules keyed by source and target.
 
-    Rules are stored as a nested dict: {source: {target: HarmonizationRule}}.
+class RuleSet:
     """
+    Flat, target-keyed collection of harmonization rules.
+
+    Rules are stored as a list, but at most one rule per target is allowed.
+    Adding a rule for an existing target replaces it and emits a warning.
+    """
+
     def __init__(self):
-        """
-        Initialize an empty rule store with a built-in no-op rule.
-        """
-        self._rules = {}
-        self._nothing = HarmonizationRule(None, None, [DoNothing()])
+        self._rules: List[HarmonizationRule] = []
 
-    def query(self, source: str, target: str = None) -> HarmonizationRule:
+    def add_rule(self, rule: HarmonizationRule) -> None:
         """
-        Retrieve a rule by source and optional target.
+        Add a rule, or replace the existing rule for the same target.
+        """
+        for i, existing in enumerate(self._rules):
+            if existing.target == rule.target:
+                print(f"Warning: rule already exists for target {rule.target}; replacing.")
+                self._rules[i] = rule
+                return
+        self._rules.append(rule)
 
-        If target is None, returns all rules for a given source.
-        If source == target, returns a no-op rule.
+    def find(self, target: str) -> HarmonizationRule:
         """
-        # support queries using just the source
-        if target is None:
-            return self._rules[source]
-        if source == target:
-            return self._nothing
-        return self._rules[source][target]
+        Return the rule producing the given target, or raise KeyError.
+        """
+        for rule in self._rules:
+            if rule.target == target:
+                return rule
+        raise KeyError(target)
 
-    def add_rule(self, rule: HarmonizationRule):
+    def for_targets(self, targets: Iterable[str]) -> List[HarmonizationRule]:
         """
-        Add or replace a harmonization rule in the store.
+        Return rules whose target appears in `targets`, preserving insertion order.
         """
-        source = rule.source
-        target = rule.target
-        if source not in self._rules:
-            self._rules[source] = {}
-        if target in self._rules[source]:
-            print(f"Warning: rule already exists for source {rule.source} and target {rule.target}.")
-        self._rules[source][target] = rule
+        wanted = set(targets)
+        return [rule for rule in self._rules if rule.target in wanted]
 
-    def list_pairs(self):
-        """
-        Return a list of (source, target) pairs for all stored rules.
-        """
-        pairs = []
-        for source, targets in self._rules.items():
-            for target in targets:
-                pairs.append((source, target))
-        return pairs
+    def all_rules(self) -> List[HarmonizationRule]:
+        return list(self._rules)
 
-    def clean(self):
-        """
-        Remove all rules from the store.
-        """
-        self._rules = {}
+    def all_targets(self) -> List[str]:
+        return [rule.target for rule in self._rules]
 
-    def save(self, output: str = "rules.json"):
+    def __len__(self) -> int:
+        return len(self._rules)
+
+    def __iter__(self):
+        return iter(self._rules)
+
+    def clean(self) -> None:
+        self._rules = []
+
+    def save(self, output: str = "rules.json") -> None:
         """
-        Serialize rules to a JSON file.
+        Serialize rules to a JSON file as a flat array.
         """
-        rules = {}
-        for source in self._rules:
-            rules[source] = {target: rule.serialize() for target, rule in self._rules[source].items()}
+        payload = [rule.serialize() for rule in self._rules]
         with open(output, "w") as out:
-            json.dump(rules, out, indent=2)
+            json.dump(payload, out, indent=2)
 
-    def load(self, rule_file: str, clean: bool = False):
+    def load(self, rule_file: str, clean: bool = False) -> None:
         """
         Load rules from a JSON file, optionally clearing existing rules first.
+
+        Accepts both the new flat-array schema and the legacy nested
+        {source: {target: rule}} schema for migration convenience.
         """
         if clean:
             self.clean()
 
         with open(rule_file, "r") as rf:
-            rules = json.load(rf)
-        for source, rules_from_source in rules.items():
-            for target, rule in rules_from_source.items():
-                self.add_rule(HarmonizationRule.from_serialization(rule))
+            data = json.load(rf)
+
+        for rule_payload in _iter_rule_payloads(data):
+            self.add_rule(HarmonizationRule.from_serialization(rule_payload))
 
 
-# Backwards-compatible alias
-RuleStore = RuleRegistry
+def _iter_rule_payloads(data):
+    """
+    Yield rule payloads from either the flat-array schema or the legacy
+    nested {source: {target: rule}} schema.
+    """
+    if isinstance(data, list):
+        yield from data
+        return
+    if isinstance(data, dict):
+        for _source, targets in data.items():
+            if not isinstance(targets, dict):
+                continue
+            for _target, rule_payload in targets.items():
+                yield rule_payload
+        return
+    raise ValueError(f"Unrecognized rules file format: expected list or dict, got {type(data).__name__}")

--- a/src/harmonization_framework/utils/transformations.py
+++ b/src/harmonization_framework/utils/transformations.py
@@ -1,43 +1,45 @@
 import json
+from typing import Dict, List
+
 import pandas as pd
+
 from ..harmonization_rule import HarmonizationRule
-from ..rule_registry import RuleRegistry
-from ..replay_log import replay_logger as rlog
 from ..harmonize import harmonize_dataset
-from typing import Dict, List, Tuple
+from ..replay_log import replay_logger as rlog
+from ..rule_registry import RuleSet
+
 
 def combine_datasets(datasets: List[pd.DataFrame]):
     combined_dataset = pd.concat(datasets, axis=0, ignore_index=True)
     combined_dataset.index.name = "id"
     return combined_dataset
 
+
 def replay(log_file: str, datasets: Dict[str, pd.DataFrame]):
-    # assume replay events on separate datasets can be interleaved arbitrarily.
-    # require ordered replay only for operations on the same dataset
-    events = {}
-    replay_rules = RuleRegistry()
+    """
+    Replay a log file against the provided datasets.
+
+    Each line of the log is a JSON event with {"dataset", "action"}, where
+    action is a serialized HarmonizationRule. Rules are grouped by dataset and
+    applied in log order via a per-dataset RuleSet.
+    """
+    events: Dict[str, List[dict]] = {}
     with open(log_file, "r") as f:
         for line in f:
             event = json.loads(line.strip())
-            dataset_name = event["dataset"]
-            if dataset_name not in events:
-                events[dataset_name] = []
-            events[dataset_name].append(event)
-            rule = event["action"]
-            replay_rules.add_rule(HarmonizationRule.from_serialization(rule))
+            events.setdefault(event["dataset"], []).append(event)
 
-    # logger for the replay
     logger = rlog.configure_logger(3, "replay_" + log_file)
 
     results = {}
-    for dataset_name in events:
-        pairs = [(event["action"]["source"], event["action"]["target"]) for event in events[dataset_name]]
-        result = harmonize_dataset(
+    for dataset_name, dataset_events in events.items():
+        rules = RuleSet()
+        for event in dataset_events:
+            rules.add_rule(HarmonizationRule.from_serialization(event["action"]))
+        results[dataset_name] = harmonize_dataset(
             datasets[dataset_name],
-            pairs,
-            replay_rules,
+            rules,
             dataset_name,
             logger,
         )
-        results[dataset_name] = result
     return results

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14,33 +14,29 @@ def _write_csv(path: Path, rows, fieldnames):
         writer.writerows(rows)
 
 
-def _write_rules(path: Path, rules: dict) -> None:
+def _write_rules(path: Path, rules: list) -> None:
     path.write_text(json.dumps(rules, indent=2) + "\n")
 
 
 def test_cli_harmonize_csv_multiple_rules(tmp_path):
-    rules_a = {
-        "a": {
-            "b": {
-                "source": "a",
-                "target": "b",
-                "operations": [
-                    {"operation": "enum_to_enum", "mapping": {"1": 10, "2": 20}, "strict": True}
-                ],
-            }
+    rules_a = [
+        {
+            "sources": ["a"],
+            "target": "b",
+            "operations": [
+                {"operation": "enum_to_enum", "mapping": {"1": 10, "2": 20}, "strict": True}
+            ],
         }
-    }
-    rules_c = {
-        "c": {
-            "d": {
-                "source": "c",
-                "target": "d",
-                "operations": [
-                    {"operation": "cast", "source": "text", "target": "integer"}
-                ],
-            }
+    ]
+    rules_c = [
+        {
+            "sources": ["c"],
+            "target": "d",
+            "operations": [
+                {"operation": "cast", "source": "text", "target": "integer"}
+            ],
         }
-    }
+    ]
 
     rules_a_path = tmp_path / "rules_a.json"
     rules_c_path = tmp_path / "rules_c.json"
@@ -75,10 +71,10 @@ def test_cli_harmonize_csv_multiple_rules(tmp_path):
 
 
 def test_cli_targets_filter_and_metadata(tmp_path):
-    rules = {
-        "a": {"b": {"source": "a", "target": "b", "operations": []}},
-        "c": {"d": {"source": "c", "target": "d", "operations": []}},
-    }
+    rules = [
+        {"sources": ["a"], "target": "b", "operations": []},
+        {"sources": ["c"], "target": "d", "operations": []},
+    ]
     rules_path = tmp_path / "rules.json"
     _write_rules(rules_path, rules)
 
@@ -108,10 +104,10 @@ def test_cli_targets_filter_and_metadata(tmp_path):
 
 
 def test_cli_missing_behavior(tmp_path, capsys):
-    rules = {
-        "missing_col": {"b": {"source": "missing_col", "target": "b", "operations": []}},
-        "a": {"c": {"source": "a", "target": "c", "operations": []}},
-    }
+    rules = [
+        {"sources": ["missing_col"], "target": "b", "operations": []},
+        {"sources": ["a"], "target": "c", "operations": []},
+    ]
     rules_path = tmp_path / "rules.json"
     _write_rules(rules_path, rules)
 
@@ -149,9 +145,9 @@ def test_cli_missing_behavior(tmp_path, capsys):
 
 
 def test_cli_tsv_autodetect(tmp_path):
-    rules = {
-        "a": {"b": {"source": "a", "target": "b", "operations": []}},
-    }
+    rules = [
+        {"sources": ["a"], "target": "b", "operations": []},
+    ]
     rules_path = tmp_path / "rules.json"
     _write_rules(rules_path, rules)
 
@@ -191,9 +187,9 @@ def test_cli_missing_rules_file(tmp_path):
 
 
 def test_cli_missing_input_file(tmp_path):
-    rules = {
-        "a": {"b": {"source": "a", "target": "b", "operations": []}},
-    }
+    rules = [
+        {"sources": ["a"], "target": "b", "operations": []},
+    ]
     rules_path = tmp_path / "rules.json"
     _write_rules(rules_path, rules)
 
@@ -204,3 +200,28 @@ def test_cli_missing_input_file(tmp_path):
             "--output", str(tmp_path / "output.csv"),
         ])
     assert exc.value.code == 2
+
+
+def test_cli_accepts_legacy_nested_rules_schema(tmp_path):
+    # Legacy nested {source: {target: rule}} schema should still load.
+    legacy_rules = {
+        "a": {"b": {"source": "a", "target": "b", "operations": []}},
+    }
+    rules_path = tmp_path / "rules.json"
+    rules_path.write_text(json.dumps(legacy_rules))
+
+    input_path = tmp_path / "input.csv"
+    _write_csv(input_path, [{"a": "1"}], fieldnames=["a"])
+    output_path = tmp_path / "output.csv"
+
+    cli.main([
+        "--rules", str(rules_path),
+        "--input", str(input_path),
+        "--output", str(output_path),
+    ])
+
+    with output_path.open() as f:
+        reader = csv.DictReader(f)
+        out_rows = list(reader)
+    assert set(reader.fieldnames) == {"b"}
+    assert out_rows == [{"b": "1"}]

--- a/tests/test_rule_serialization.py
+++ b/tests/test_rule_serialization.py
@@ -7,11 +7,11 @@ from harmonization_framework.primitives.reduce import Reduction
 
 
 def test_rule_serializes_with_empty_operations():
-    rule = HarmonizationRule("source_col", "target_col", None)
+    rule = HarmonizationRule(["source_col"], "target_col", None)
     payload = rule.serialize()
 
     assert payload == {
-        "source": "source_col",
+        "sources": ["source_col"],
         "target": "target_col",
         "operations": [],
     }
@@ -22,14 +22,14 @@ def test_rule_serializes_with_empty_operations():
 
 def test_rule_serialization_roundtrip_and_transform():
     rule = HarmonizationRule(
-        "age_text",
+        ["age_text"],
         "age_years",
         [Cast("text", "integer"), Round(0)],
         metadata={"comments": ["source: demo"], "provenance": "demo"},
     )
 
     payload = rule.serialize()
-    assert payload["source"] == "age_text"
+    assert payload["sources"] == ["age_text"]
     assert payload["target"] == "age_years"
     assert [op["operation"] for op in payload["operations"]] == ["cast", "round"]
 
@@ -40,7 +40,7 @@ def test_rule_serialization_roundtrip_and_transform():
 
 def test_rule_from_serialization_unknown_operation_raises():
     payload = {
-        "source": "a",
+        "sources": ["a"],
         "target": "b",
         "operations": [{"operation": "not_a_real_op"}],
     }
@@ -50,13 +50,13 @@ def test_rule_from_serialization_unknown_operation_raises():
 
 
 def test_rule_transform_with_do_nothing():
-    rule = HarmonizationRule("x", "y", [DoNothing()])
+    rule = HarmonizationRule(["x"], "y", [DoNothing()])
     assert rule.transform("abc") == "abc"
 
 
 def test_rule_with_parse_array_then_reduce_sum():
     rule = HarmonizationRule(
-        "week_hours",
+        ["week_hours"],
         "total_hours",
         [ParseArray(), Reduce(Reduction.SUM)],
     )
@@ -64,3 +64,33 @@ def test_rule_with_parse_array_then_reduce_sum():
 
     roundtrip = HarmonizationRule.from_serialization(payload)
     assert roundtrip.transform("[8, 8, 8, 8, 6]") == 38
+
+
+def test_rule_legacy_source_key_is_accepted():
+    # Old schema used `"source": "x"` as a scalar string. from_serialization
+    # should silently wrap it into a single-element `sources` list.
+    legacy_payload = {
+        "source": "age_text",
+        "target": "age_years",
+        "operations": [{"operation": "cast", "source": "text", "target": "integer"}],
+    }
+    rule = HarmonizationRule.from_serialization(legacy_payload)
+    assert rule.sources == ["age_text"]
+    assert rule.target == "age_years"
+    assert rule.transform("42") == 42
+
+    # And it re-serializes in the new schema.
+    assert rule.serialize()["sources"] == ["age_text"]
+
+
+def test_multi_source_rule_passes_list_to_operations():
+    # A multi-source rule should pass the full list of values to the first
+    # operation. We use a small custom-style operation by composing primitives
+    # that operate on iterables — Reduce takes a list and reduces it.
+    rule = HarmonizationRule(
+        ["a", "b", "c"],
+        "total",
+        [Reduce(Reduction.SUM)],
+    )
+    assert rule.sources == ["a", "b", "c"]
+    assert rule.transform([1, 2, 3]) == 6


### PR DESCRIPTION
## Summary

Refactor of the rule model and registry to prepare for multi-source harmonization (#90). Closes #102.

- **`HarmonizationRule`**: `source: str` becomes `sources: List[str]`. Single-source rules are the one-element case. `transform()` unwraps the singleton so existing primitives still receive a scalar; multi-source rules pass the full list through.
- **`RuleSet` replaces `RuleRegistry`**: flat list of rules keyed on target. One rule per target (warns and replaces on collision). JSON schema becomes a flat array. For migration, `RuleSet.load()` and `HarmonizationRule.from_serialization()` still accept the legacy nested `{source: {target: rule}}` / scalar `"source": "x"` formats.
- **`harmonize_dataset`** runs every rule in the `RuleSet` (no more `harmonization_pairs`). Source columns are read via `df[rule.sources].apply(axis=1)`.
- **CLI `--targets`** becomes a load-time filter on the `RuleSet`. `--on-missing` checks every entry of `rule.sources`; a multi-source rule is skipped if any source is missing.
- **RPC API**: `mode=pairs`/`harmonization_pairs` removed (per the additional design decision in the issue thread) — the RPC always runs every rule in the rules file. To run a subset, construct a rules file containing only the desired targets. TS client types updated to match.
- **`utils.transformations.replay()`** rewritten to build a per-dataset `RuleSet`.
- **Demo rules files** migrated to the flat array schema. `Rule`, `RuleStore`, and `RuleRegistry` aliases removed.

### Breaking changes
- JSON rule files now use a flat array (legacy nested schema still loads).
- `harmonize_dataset(... harmonization_pairs=...)` signature changed; `harmonization_pairs` is gone.
- `harmonize` RPC drops `mode` and `pairs`.
- `Rule`, `RuleStore`, `RuleRegistry` (the class) symbols are removed; import `RuleSet` instead.

### Notes
- `demo/integration.ipynb` still imports an even older `RuleStore`/`rule_store` that didn't exist on `main`; it was already stale and is left untouched.

## Test plan

- [x] `pytest` — all 75 tests pass, including new coverage for legacy schema compat and multi-source transform
- [x] `demo/harmonize_example/run_example.py` runs end-to-end against the migrated flat-array rules file
- [x] Reviewer to confirm RPC breaking change is acceptable (was also discussed in the issue thread)

🤖 Generated with [Claude Code](https://claude.com/claude-code)