### PR TITLE
Multi-source to single-target harmonization with MapEach primitive (#90)

### DIFF
--- a/demo/harmonize_example/input.csv
+++ b/demo/harmonize_example/input.csv
@@ -1,4 +1,4 @@
-age,weight_lbs,name,visit_type_code
-10,78.26,"Smith, Alice",BL
-5,44.5,"Jones, Bob",FU
-8,92.2,"Nguyen, Carol",SC
+age,weight_lbs,name,visit_type_code,flag_baseline,flag_followup,flag_screening
+10,78.26,"Smith, Alice",BL,1,0,0
+5,44.5,"Jones, Bob",FU,0,1,0
+8,92.2,"Nguyen, Carol",SC,0,0,1

--- a/demo/harmonize_example/output.csv
+++ b/demo/harmonize_example/output.csv
@@ -1,4 +1,4 @@
-given_name,family_name,age_years,weight_kg,visit_type_label,source dataset,original_id,age,weight_lbs,name,visit_type_code
-Alice,Smith,10,35.50,baseline,demo,0,10,78.26,"Smith, Alice",BL
-Bob,Jones,5,20.18,follow_up,demo,1,5,44.5,"Jones, Bob",FU
-Carol,Nguyen,8,41.82,screening,demo,2,8,92.2,"Nguyen, Carol",SC
+given_name,family_name,age_years,weight_kg,visit_type_label,visit_phase,source dataset,original_id,age,weight_lbs,name,visit_type_code,flag_baseline,flag_followup,flag_screening
+Alice,Smith,10,35.50,baseline,baseline,demo,0,10,78.26,"Smith, Alice",BL,1,0,0
+Bob,Jones,5,20.18,follow_up,follow_up,demo,1,5,44.5,"Jones, Bob",FU,0,1,0
+Carol,Nguyen,8,41.82,screening,screening,demo,2,8,92.2,"Nguyen, Carol",SC,0,0,1

--- a/demo/harmonize_example/rules.json
+++ b/demo/harmonize_example/rules.json
@@ -63,5 +63,30 @@
         "strict": false
       }
     ]
+  },
+  {
+    "sources": ["flag_baseline", "flag_followup", "flag_screening"],
+    "target": "visit_phase",
+    "operations": [
+      {
+        "operation": "reduce",
+        "reduction": "one-hot"
+      },
+      {
+        "operation": "cast",
+        "source": "integer",
+        "target": "text"
+      },
+      {
+        "operation": "enum_to_enum",
+        "mapping": {
+          "0": "baseline",
+          "1": "follow_up",
+          "2": "screening"
+        },
+        "default": "unknown",
+        "strict": false
+      }
+    ]
   }
 ]

--- a/demo/harmonize_example/run_example.py
+++ b/demo/harmonize_example/run_example.py
@@ -46,6 +46,7 @@ def main() -> None:
         "age_years",
         "weight_kg",
         "visit_type_label",
+        "visit_phase",
         "source dataset",
         "original_id",
     ]

--- a/src/harmonization_framework/harmonization_rule.py
+++ b/src/harmonization_framework/harmonization_rule.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, List, Optional
 from .primitives.base import PrimitiveOperation
-from .primitives import PrimitiveVocabulary, Bin, Cast, ConvertDate, ConvertUnits, DoNothing, EnumToEnum, FormatNumber, NormalizeBoolean, NormalizeText, Offset, ParseArray, Reduce, Round, Scale, Substitute, Threshold, Truncate
+from .primitives.factory import deserialize_operation
 
 import json
 
@@ -67,44 +67,5 @@ class HarmonizationRule:
         target = serialization["target"]
         operations = serialization["operations"]
         metadata = serialization.get("metadata")
-        transformation = []
-        for operation in operations:
-            match operation["operation"]:
-                case PrimitiveVocabulary.BIN.value:
-                    primitive = Bin.from_serialization(operation)
-                case PrimitiveVocabulary.CAST.value:
-                    primitive = Cast.from_serialization(operation)
-                case PrimitiveVocabulary.CONVERT_DATE.value:
-                    primitive = ConvertDate.from_serialization(operation)
-                case PrimitiveVocabulary.CONVERT_UNITS.value:
-                    primitive = ConvertUnits.from_serialization(operation)
-                case PrimitiveVocabulary.DO_NOTHING.value:
-                    primitive = DoNothing.from_serialization(operation)
-                case PrimitiveVocabulary.ENUM_TO_ENUM.value:
-                    primitive = EnumToEnum.from_serialization(operation)
-                case PrimitiveVocabulary.FORMAT_NUMBER.value:
-                    primitive = FormatNumber.from_serialization(operation)
-                case PrimitiveVocabulary.NORMALIZE_BOOLEAN.value:
-                    primitive = NormalizeBoolean.from_serialization(operation)
-                case PrimitiveVocabulary.NORMALIZE_TEXT.value:
-                    primitive = NormalizeText.from_serialization(operation)
-                case PrimitiveVocabulary.OFFSET.value:
-                    primitive = Offset.from_serialization(operation)
-                case PrimitiveVocabulary.PARSE_ARRAY.value:
-                    primitive = ParseArray.from_serialization(operation)
-                case PrimitiveVocabulary.REDUCE.value:
-                    primitive = Reduce.from_serialization(operation)
-                case PrimitiveVocabulary.ROUND.value:
-                    primitive = Round.from_serialization(operation)
-                case PrimitiveVocabulary.SCALE.value:
-                    primitive = Scale.from_serialization(operation)
-                case PrimitiveVocabulary.SUBSTITUTE.value:
-                    primitive = Substitute.from_serialization(operation)
-                case PrimitiveVocabulary.THRESHOLD.value:
-                    primitive = Threshold.from_serialization(operation)
-                case PrimitiveVocabulary.TRUNCATE.value:
-                    primitive = Truncate.from_serialization(operation)
-                case _:
-                    raise ValueError(f"Unknown operation: {operation['operation']}")
-            transformation.append(primitive)
+        transformation = [deserialize_operation(op) for op in operations]
         return HarmonizationRule(sources, target, transformation, metadata=metadata)

--- a/src/harmonization_framework/primitives/__init__.py
+++ b/src/harmonization_framework/primitives/__init__.py
@@ -5,6 +5,7 @@ from .dates import ConvertDate
 from .donothing import DoNothing
 from .enum2enum import EnumToEnum
 from .format_number import FormatNumber
+from .map_each import MapEach
 from .normalize_boolean import NormalizeBoolean
 from .normalize import NormalizeText
 from .offset import Offset

--- a/src/harmonization_framework/primitives/factory.py
+++ b/src/harmonization_framework/primitives/factory.py
@@ -1,0 +1,79 @@
+"""
+Deserialize a primitive operation from its JSON-friendly dict form.
+
+Lives in its own module so that primitives that hold nested operations
+(e.g. MapEach) can deserialize their children without importing
+HarmonizationRule, and without forcing a circular import through
+primitives/__init__.py.
+"""
+
+from typing import Any, Dict
+
+from .base import PrimitiveOperation
+from .bin_primitive import Bin
+from .cast import Cast
+from .dates import ConvertDate
+from .donothing import DoNothing
+from .enum2enum import EnumToEnum
+from .format_number import FormatNumber
+from .map_each import MapEach
+from .normalize import NormalizeText
+from .normalize_boolean import NormalizeBoolean
+from .offset import Offset
+from .parse_array import ParseArray
+from .reduce import Reduce
+from .round_decimal import Round
+from .scale import Scale
+from .substitute import Substitute
+from .threshold import Threshold
+from .truncate import Truncate
+from .units import ConvertUnits
+from .vocabulary import PrimitiveVocabulary
+
+
+def deserialize_operation(operation: Dict[str, Any]) -> PrimitiveOperation:
+    """
+    Build a PrimitiveOperation from its serialized dict.
+
+    Raises ValueError for unknown operation names.
+    """
+    name = operation["operation"]
+    match name:
+        case PrimitiveVocabulary.BIN.value:
+            return Bin.from_serialization(operation)
+        case PrimitiveVocabulary.CAST.value:
+            return Cast.from_serialization(operation)
+        case PrimitiveVocabulary.CONVERT_DATE.value:
+            return ConvertDate.from_serialization(operation)
+        case PrimitiveVocabulary.CONVERT_UNITS.value:
+            return ConvertUnits.from_serialization(operation)
+        case PrimitiveVocabulary.DO_NOTHING.value:
+            return DoNothing.from_serialization(operation)
+        case PrimitiveVocabulary.ENUM_TO_ENUM.value:
+            return EnumToEnum.from_serialization(operation)
+        case PrimitiveVocabulary.FORMAT_NUMBER.value:
+            return FormatNumber.from_serialization(operation)
+        case PrimitiveVocabulary.MAP_EACH.value:
+            return MapEach.from_serialization(operation)
+        case PrimitiveVocabulary.NORMALIZE_BOOLEAN.value:
+            return NormalizeBoolean.from_serialization(operation)
+        case PrimitiveVocabulary.NORMALIZE_TEXT.value:
+            return NormalizeText.from_serialization(operation)
+        case PrimitiveVocabulary.OFFSET.value:
+            return Offset.from_serialization(operation)
+        case PrimitiveVocabulary.PARSE_ARRAY.value:
+            return ParseArray.from_serialization(operation)
+        case PrimitiveVocabulary.REDUCE.value:
+            return Reduce.from_serialization(operation)
+        case PrimitiveVocabulary.ROUND.value:
+            return Round.from_serialization(operation)
+        case PrimitiveVocabulary.SCALE.value:
+            return Scale.from_serialization(operation)
+        case PrimitiveVocabulary.SUBSTITUTE.value:
+            return Substitute.from_serialization(operation)
+        case PrimitiveVocabulary.THRESHOLD.value:
+            return Threshold.from_serialization(operation)
+        case PrimitiveVocabulary.TRUNCATE.value:
+            return Truncate.from_serialization(operation)
+        case _:
+            raise ValueError(f"Unknown operation: {name}")

--- a/src/harmonization_framework/primitives/map_each.py
+++ b/src/harmonization_framework/primitives/map_each.py
@@ -1,0 +1,49 @@
+from typing import Any, List
+
+from .base import PrimitiveOperation
+
+
+class MapEach(PrimitiveOperation):
+    """
+    Apply a nested chain of operations to each element of a list.
+
+    Useful for multi-source rules where each source value needs the same
+    per-element transform (e.g. cast each one-hot flag to int) before a
+    list-consuming step like Reduce.
+
+    The wrapped operations run in order on each element. Input must be a
+    list or tuple; output is a list of the same length.
+    """
+
+    def __init__(self, operations: List[PrimitiveOperation]):
+        self.operations = list(operations)
+
+    def __str__(self):
+        nested = "\n".join(f"  {op}" for op in self.operations)
+        return f"For each element apply:\n{nested}"
+
+    def to_dict(self):
+        return {
+            "operation": "map_each",
+            "operations": [op.to_dict() for op in self.operations],
+        }
+
+    def transform(self, values: Any) -> List[Any]:
+        if not isinstance(values, (list, tuple)):
+            raise TypeError(f"MapEach expects a list or tuple, got {type(values).__name__}")
+        results = []
+        for value in values:
+            current = value
+            for op in self.operations:
+                current = op(current)
+            results.append(current)
+        return results
+
+    @classmethod
+    def from_serialization(cls, serialization):
+        # Imported here to avoid a circular import: factory imports MapEach,
+        # MapEach.from_serialization needs the factory.
+        from .factory import deserialize_operation
+
+        operations = [deserialize_operation(op) for op in serialization["operations"]]
+        return MapEach(operations)

--- a/src/harmonization_framework/primitives/vocabulary.py
+++ b/src/harmonization_framework/primitives/vocabulary.py
@@ -8,6 +8,7 @@ class PrimitiveVocabulary(Enum):
     DO_NOTHING = "do_nothing"
     ENUM_TO_ENUM = "enum_to_enum"
     FORMAT_NUMBER = "format_number"
+    MAP_EACH = "map_each"
     NORMALIZE_BOOLEAN = "normalize_boolean"
     NORMALIZE_TEXT = "normalize_text"
     OFFSET = "offset"

--- a/tests/test_multi_source.py
+++ b/tests/test_multi_source.py
@@ -1,0 +1,200 @@
+import csv
+import json
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from harmonization_framework import cli
+from harmonization_framework.harmonization_rule import HarmonizationRule
+from harmonization_framework.harmonize import harmonize_dataset
+from harmonization_framework.primitives import Cast, EnumToEnum, MapEach, Reduce
+from harmonization_framework.primitives.reduce import Reduction
+from harmonization_framework.rule_registry import RuleSet
+
+
+def test_multi_source_rule_serialization_roundtrip():
+    rule = HarmonizationRule(
+        ["flag_baseline", "flag_followup", "flag_screening"],
+        "visit_type",
+        [
+            MapEach([Cast("text", "integer")]),
+            Reduce(Reduction.ONEHOT),
+            EnumToEnum({0: "baseline", 1: "follow_up", 2: "screening"}),
+        ],
+    )
+    payload = rule.serialize()
+
+    assert payload["sources"] == ["flag_baseline", "flag_followup", "flag_screening"]
+    assert payload["target"] == "visit_type"
+    assert [op["operation"] for op in payload["operations"]] == [
+        "map_each",
+        "reduce",
+        "enum_to_enum",
+    ]
+
+    roundtrip = HarmonizationRule.from_serialization(payload)
+    assert roundtrip.serialize() == payload
+    # Three flags, follow_up = index 1
+    assert roundtrip.transform(["0", "1", "0"]) == "follow_up"
+
+
+def test_harmonize_dataset_with_multi_source_one_hot_rule():
+    rules = RuleSet()
+    rules.add_rule(
+        HarmonizationRule(
+            ["flag_baseline", "flag_followup", "flag_screening"],
+            "visit_type",
+            [
+                Reduce(Reduction.ONEHOT),
+                EnumToEnum({0: "baseline", 1: "follow_up", 2: "screening"}),
+            ],
+        )
+    )
+    df = pd.DataFrame(
+        [
+            {"flag_baseline": 1, "flag_followup": 0, "flag_screening": 0},
+            {"flag_baseline": 0, "flag_followup": 1, "flag_screening": 0},
+            {"flag_baseline": 0, "flag_followup": 0, "flag_screening": 1},
+        ]
+    )
+
+    out = harmonize_dataset(df, rules, dataset_name="test")
+    assert out["visit_type"].tolist() == ["baseline", "follow_up", "screening"]
+
+
+def test_harmonize_dataset_multi_source_sum_with_map_each():
+    rules = RuleSet()
+    rules.add_rule(
+        HarmonizationRule(
+            ["mon", "tue", "wed", "thu", "fri"],
+            "total_hours",
+            [
+                MapEach([Cast("text", "integer")]),
+                Reduce(Reduction.SUM),
+            ],
+        )
+    )
+    df = pd.DataFrame(
+        [
+            {"mon": "8", "tue": "8", "wed": "8", "thu": "8", "fri": "6"},
+            {"mon": "4", "tue": "0", "wed": "8", "thu": "8", "fri": "8"},
+        ]
+    )
+
+    out = harmonize_dataset(df, rules, dataset_name="test")
+    assert out["total_hours"].tolist() == [38, 28]
+
+
+def _write_csv(path: Path, rows, fieldnames):
+    with path.open("w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def test_cli_runs_multi_source_rule(tmp_path):
+    rules = [
+        {
+            "sources": ["flag_baseline", "flag_followup", "flag_screening"],
+            "target": "visit_type",
+            "operations": [
+                {"operation": "map_each", "operations": [{"operation": "cast", "source": "text", "target": "integer"}]},
+                {"operation": "reduce", "reduction": "one-hot"},
+                {
+                    "operation": "cast",
+                    "source": "integer",
+                    "target": "text",
+                },
+                {
+                    "operation": "enum_to_enum",
+                    "mapping": {"0": "baseline", "1": "follow_up", "2": "screening"},
+                    "strict": True,
+                },
+            ],
+        }
+    ]
+    rules_path = tmp_path / "rules.json"
+    rules_path.write_text(json.dumps(rules) + "\n")
+
+    input_path = tmp_path / "input.csv"
+    _write_csv(
+        input_path,
+        [
+            {"flag_baseline": "1", "flag_followup": "0", "flag_screening": "0"},
+            {"flag_baseline": "0", "flag_followup": "0", "flag_screening": "1"},
+        ],
+        fieldnames=["flag_baseline", "flag_followup", "flag_screening"],
+    )
+
+    output_path = tmp_path / "output.csv"
+    cli.main([
+        "--rules", str(rules_path),
+        "--input", str(input_path),
+        "--output", str(output_path),
+    ])
+
+    with output_path.open() as f:
+        out_rows = list(csv.DictReader(f))
+    assert out_rows == [{"visit_type": "baseline"}, {"visit_type": "screening"}]
+
+
+def test_cli_multi_source_on_missing_skips_when_any_source_absent(tmp_path):
+    # Multi-source rule needs all three flags; only two are present in the input.
+    # A single-source rule on a present column should still run.
+    rules = [
+        {
+            "sources": ["flag_baseline", "flag_followup", "flag_screening"],
+            "target": "visit_type",
+            "operations": [{"operation": "reduce", "reduction": "one-hot"}],
+        },
+        {"sources": ["age"], "target": "age_years", "operations": []},
+    ]
+    rules_path = tmp_path / "rules.json"
+    rules_path.write_text(json.dumps(rules) + "\n")
+
+    input_path = tmp_path / "input.csv"
+    _write_csv(
+        input_path,
+        [{"flag_baseline": "1", "flag_followup": "0", "age": "10"}],
+        fieldnames=["flag_baseline", "flag_followup", "age"],
+    )
+
+    output_path = tmp_path / "output.csv"
+    cli.main([
+        "--rules", str(rules_path),
+        "--input", str(input_path),
+        "--output", str(output_path),
+        "--on-missing", "skip",
+    ])
+
+    with output_path.open() as f:
+        reader = csv.DictReader(f)
+        out_rows = list(reader)
+    assert set(reader.fieldnames) == {"age_years"}
+    assert out_rows == [{"age_years": "10"}]
+
+
+def test_cli_multi_source_on_missing_error_raises(tmp_path):
+    rules = [
+        {
+            "sources": ["a", "b"],
+            "target": "combined",
+            "operations": [{"operation": "reduce", "reduction": "sum"}],
+        }
+    ]
+    rules_path = tmp_path / "rules.json"
+    rules_path.write_text(json.dumps(rules) + "\n")
+
+    input_path = tmp_path / "input.csv"
+    _write_csv(input_path, [{"a": "1"}], fieldnames=["a"])
+    output_path = tmp_path / "output.csv"
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main([
+            "--rules", str(rules_path),
+            "--input", str(input_path),
+            "--output", str(output_path),
+            "--on-missing", "error",
+        ])
+    assert exc.value.code == 2

--- a/tests/test_primitives_serialization.py
+++ b/tests/test_primitives_serialization.py
@@ -8,6 +8,7 @@ from harmonization_framework.primitives import (
     DoNothing,
     EnumToEnum,
     FormatNumber,
+    MapEach,
     NormalizeBoolean,
     NormalizeText,
     Offset,
@@ -460,3 +461,41 @@ def test_do_nothing_serialization_and_transform():
     assert roundtrip.to_dict() == payload
     assert primitive.transform("abc") == "abc"
     assert primitive.transform([1, 2]) == [1, 2]
+
+
+def test_map_each_serialization_and_transform():
+    primitive = MapEach([Cast("text", "integer"), Offset(1)])
+    payload = primitive.to_dict()
+
+    assert payload == {
+        "operation": "map_each",
+        "operations": [
+            {"operation": "cast", "source": "text", "target": "integer"},
+            {"operation": "offset", "offset": 1},
+        ],
+    }
+
+    roundtrip = MapEach.from_serialization(payload)
+    assert roundtrip.to_dict() == payload
+    assert roundtrip.transform(["1", "2", "3"]) == [2, 3, 4]
+
+
+def test_map_each_then_reduce_one_hot_pipeline():
+    # Composing MapEach + Reduce(one-hot) is the canonical multi-source pipeline:
+    # cast each string flag to int, then pick the index of the active bit.
+    map_each = MapEach([Cast("text", "integer")])
+    reduce_onehot = Reduce(Reduction.ONEHOT)
+
+    flags = ["0", "1", "0"]
+    assert reduce_onehot.transform(map_each.transform(flags)) == 1
+
+
+def test_map_each_rejects_non_list():
+    primitive = MapEach([Offset(1)])
+    with pytest.raises(TypeError, match="list or tuple"):
+        primitive.transform(5)
+
+
+def test_map_each_empty_operations_is_identity():
+    primitive = MapEach([])
+    assert primitive.transform([1, 2, 3]) == [1, 2, 3]


### PR DESCRIPTION
## Summary

Builds on #102 to deliver multi-source → single-target harmonization end-to-end. The rule model already accepts `sources: List[str]` and `harmonize_dataset` already reads multi-column inputs — this PR adds the missing piece (a per-element transform), verifies the full pipeline against real data, and documents the pattern in the demo.

- **New `MapEach` primitive**: applies a nested chain of operations to each element of a list. Composes naturally with `Reduce` so a multi-source rule can do per-source casts/normalisations before a list-consuming step. Serialisation uses a nested `operations` array.
- **New `primitives/factory.py`**: shared `deserialize_operation()` helper. Lets `MapEach` deserialise its children without importing `HarmonizationRule` (avoids a circular import). `HarmonizationRule.from_serialization` collapses to a one-line list comp.
- **Multi-source tests** (`tests/test_multi_source.py`, 6 tests): rule serialisation roundtrip with multi-source + `MapEach`; `harmonize_dataset` with one-hot → enum and with `MapEach` + `Reduce(sum)`; CLI execution of a multi-source rule; `--on-missing skip` and `--on-missing error` semantics when any source column is absent.
- **`MapEach` unit tests** (4 added to `tests/test_primitives_serialization.py`): serialisation roundtrip; canonical `MapEach` + `Reduce(one-hot)` pipeline; rejects non-list input; empty-operations identity.
- **Demo**: added one-hot flag columns (`flag_baseline` / `flag_followup` / `flag_screening`) to `demo/harmonize_example/input.csv` plus a multi-source rule producing a `visit_phase` column. The demo now yields `visit_type_label` (derived from the enum code) and `visit_phase` (derived from the one-hot flags) with matching values per row.

### Canonical multi-source pipeline

```json
{
  \"sources\": [\"flag_baseline\", \"flag_followup\", \"flag_screening\"],
  \"target\": \"visit_phase\",
  \"operations\": [
    {\"operation\": \"reduce\", \"reduction\": \"one-hot\"},
    {\"operation\": \"cast\", \"source\": \"integer\", \"target\": \"text\"},
    {\"operation\": \"enum_to_enum\", \"mapping\": {\"0\": \"baseline\", \"1\": \"follow_up\", \"2\": \"screening\"}}
  ]
}
```

`MapEach` is used when each source value needs its own transform first — for example casting string CSV values to int before `Reduce(sum)`:

```json
{
  \"operations\": [
    {\"operation\": \"map_each\", \"operations\": [{\"operation\": \"cast\", \"source\": \"text\", \"target\": \"integer\"}]},
    {\"operation\": \"reduce\", \"reduction\": \"sum\"}
  ]
}
```

### Backwards compatibility

Purely additive — no breaking changes. Existing single-source rules and serialised payloads are unaffected.

## Test plan

- [x] `pytest` — all 85 tests pass (10 new: 6 multi-source + 4 MapEach)
- [x] `demo/harmonize_example/run_example.py` runs end-to-end; `visit_phase` and `visit_type_label` agree row-for-row
- [ ] Reviewer to sanity-check the `MapEach` serialisation shape (`operation: \"map_each\"` with nested `operations: [...]`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)