### PR TITLE
Handle None/NaN/pd.NA in primitives (#25)

### DIFF
--- a/src/harmonization_framework/primitives/base.py
+++ b/src/harmonization_framework/primitives/base.py
@@ -1,10 +1,36 @@
 from typing import Any, Dict
 
 import json
+import math
+
+import pandas as pd
 
 """
 Base interfaces and utilities for primitive operations.
 """
+
+
+def isnull(value: Any) -> bool:
+    """
+    Return True if `value` represents a missing/null value.
+
+    Recognised forms:
+    - Python `None`
+    - `float('nan')` (the legacy missing-value sentinel pandas inserts into
+      numeric columns when a CSV cell is blank)
+    - `pd.NA` (pandas nullable-dtype scalar)
+
+    Lists, tuples, and strings are never considered null — only scalar values are.
+    """
+    if value is None:
+        return True
+    if isinstance(value, float) and math.isnan(value):
+        return True
+    # pd.NA does not compare equal to anything, and `isinstance(pd.NA, ...)`
+    # is not robust across pandas versions, so use `is` against the singleton.
+    if value is pd.NA:
+        return True
+    return False
 
 class PrimitiveOperation:
     def __init__(self):
@@ -62,5 +88,31 @@ def support_iterable(transform):
     def wrapper(self, value):
         if isinstance(value, (list, tuple)):
             return [transform(self, v) for v in value]
+        return transform(self, value)
+    return wrapper
+
+
+def handle_null(transform):
+    """
+    Decorator that makes a scalar transform pass `None`/NaN/pd.NA through unchanged.
+
+    Apply to primitives whose transform expects a non-null scalar (Cast, Scale,
+    Bin, Round, etc.). The decorated method is never called for a null input;
+    the null value is returned as-is.
+
+    Decorator order with `@support_iterable`:
+
+        @support_iterable
+        @handle_null
+        def transform(self, value):
+            ...
+
+    `@support_iterable` is the outermost decorator so that it can fan a list
+    out to per-element calls; each per-element call then goes through
+    `@handle_null` before reaching the real transform.
+    """
+    def wrapper(self, value):
+        if isnull(value):
+            return value
         return transform(self, value)
     return wrapper

--- a/src/harmonization_framework/primitives/bin_primitive.py
+++ b/src/harmonization_framework/primitives/bin_primitive.py
@@ -1,4 +1,4 @@
-from .base import PrimitiveOperation, support_iterable
+from .base import PrimitiveOperation, handle_null, support_iterable
 from typing import Any, List, Tuple
 
 class _IntervalNode:
@@ -35,6 +35,7 @@ class Bin(PrimitiveOperation):
         return output
 
     @support_iterable
+    @handle_null
     def transform(self, value: int) -> Any:
         transformed = self._query(value, self._tree)
         if transformed is None:

--- a/src/harmonization_framework/primitives/cast.py
+++ b/src/harmonization_framework/primitives/cast.py
@@ -1,4 +1,4 @@
-from .base import PrimitiveOperation, support_iterable
+from .base import PrimitiveOperation, handle_null, support_iterable
 from enum import Enum
 from typing import Any
 
@@ -35,6 +35,7 @@ class Cast(PrimitiveOperation):
         return output
 
     @support_iterable
+    @handle_null
     def transform(self, value: Any) -> Any:
         match self.target:
             case "text":

--- a/src/harmonization_framework/primitives/dates.py
+++ b/src/harmonization_framework/primitives/dates.py
@@ -1,4 +1,4 @@
-from .base import PrimitiveOperation, support_iterable
+from .base import PrimitiveOperation, handle_null, support_iterable
 from datetime import datetime
 
 class ConvertDate(PrimitiveOperation):
@@ -26,6 +26,7 @@ class ConvertDate(PrimitiveOperation):
         return output
 
     @support_iterable
+    @handle_null
     def transform(self, value: str) -> str:
         try:
             dt = datetime.strptime(value, self.source_format)

--- a/src/harmonization_framework/primitives/format_number.py
+++ b/src/harmonization_framework/primitives/format_number.py
@@ -1,4 +1,4 @@
-from .base import PrimitiveOperation, support_iterable
+from .base import PrimitiveOperation, handle_null, support_iterable
 from typing import Union
 
 class FormatNumber(PrimitiveOperation):
@@ -25,6 +25,7 @@ class FormatNumber(PrimitiveOperation):
         }
 
     @support_iterable
+    @handle_null
     def transform(self, value: Union[int, float]) -> str:
         """Format the numeric value to the configured decimal precision."""
         if not isinstance(value, (int, float)) or isinstance(value, bool):

--- a/src/harmonization_framework/primitives/map_each.py
+++ b/src/harmonization_framework/primitives/map_each.py
@@ -1,6 +1,6 @@
 from typing import Any, List
 
-from .base import PrimitiveOperation
+from .base import PrimitiveOperation, isnull
 
 
 class MapEach(PrimitiveOperation):
@@ -29,10 +29,25 @@ class MapEach(PrimitiveOperation):
         }
 
     def transform(self, values: Any) -> List[Any]:
+        """
+        Apply the nested op chain to every element of `values`.
+
+        MapEach rejects null elements rather than silently passing them
+        through, so that a multi-source rule producing a partial input is
+        surfaced as a data-quality issue. Scalar primitives downstream of
+        MapEach handle their own nulls via @handle_null, but in a multi-source
+        list a null element usually means the source column itself is missing
+        for that row — better to fail loudly.
+        """
         if not isinstance(values, (list, tuple)):
             raise TypeError(f"MapEach expects a list or tuple, got {type(values).__name__}")
         results = []
-        for value in values:
+        for index, value in enumerate(values):
+            if isnull(value):
+                raise ValueError(
+                    f"MapEach received a null value at position {index}; "
+                    f"map_each will not silently pass nulls through."
+                )
             current = value
             for op in self.operations:
                 current = op(current)

--- a/src/harmonization_framework/primitives/normalize.py
+++ b/src/harmonization_framework/primitives/normalize.py
@@ -1,7 +1,7 @@
 import re
 import unicodedata
 
-from .base import PrimitiveOperation, support_iterable
+from .base import PrimitiveOperation, handle_null, support_iterable
 from enum import Enum
 
 class Normalization(Enum):
@@ -31,6 +31,7 @@ class NormalizeText(PrimitiveOperation):
         return output
 
     @support_iterable
+    @handle_null
     def transform(self, value: str) -> str:
         match self.normalization:
             case Normalization.STRIP:

--- a/src/harmonization_framework/primitives/offset.py
+++ b/src/harmonization_framework/primitives/offset.py
@@ -1,4 +1,4 @@
-from .base import PrimitiveOperation, support_iterable
+from .base import PrimitiveOperation, handle_null, support_iterable
 from typing import Union
 
 class Offset(PrimitiveOperation):
@@ -25,6 +25,7 @@ class Offset(PrimitiveOperation):
         return output
 
     @support_iterable
+    @handle_null
     def transform(self, value: Union[int, float]) -> Union[int, float]:
         """
         Add the configured offset to the input value.

--- a/src/harmonization_framework/primitives/reduce.py
+++ b/src/harmonization_framework/primitives/reduce.py
@@ -1,4 +1,4 @@
-from .base import PrimitiveOperation
+from .base import PrimitiveOperation, isnull
 from enum import Enum
 from typing import Any, List
 
@@ -44,11 +44,23 @@ class Reduce(PrimitiveOperation):
         - any/none/all: boolean reductions (return 0/1)
         - one-hot: return the index of the single active bit (or None on error)
         - sum: numeric sum
+
+        Reduce intentionally rejects null elements rather than silently dropping
+        them. A multi-source rule with a missing source produces a partial input
+        that should be surfaced as a data-quality issue, not papered over. Use
+        the CLI's `--on-missing` policy to control whole-column behavior; if you
+        need to combine values across rows ignoring nulls, drop them upstream.
         """
         if not isinstance(values, (list, tuple)):
             raise TypeError(f"Reduce expects a list or tuple, got {type(values).__name__}")
         if len(values) == 0:
             raise ValueError("Reduce expects a non-empty list of values")
+        for index, value in enumerate(values):
+            if isnull(value):
+                raise ValueError(
+                    f"Reduce received a null value at position {index}; "
+                    f"reduce will not silently drop missing inputs."
+                )
         match self.reduction:
             case Reduction.ANY:
                 return int(any(values))

--- a/src/harmonization_framework/primitives/round_decimal.py
+++ b/src/harmonization_framework/primitives/round_decimal.py
@@ -1,4 +1,4 @@
-from .base import PrimitiveOperation, support_iterable
+from .base import PrimitiveOperation, handle_null, support_iterable
 from typing import Union
 
 class Round(PrimitiveOperation):
@@ -30,6 +30,7 @@ class Round(PrimitiveOperation):
         return output
 
     @support_iterable
+    @handle_null
     def transform(self, value: Union[float]) -> Union[float]:
         """
         Round the value to the configured precision.

--- a/src/harmonization_framework/primitives/scale.py
+++ b/src/harmonization_framework/primitives/scale.py
@@ -1,4 +1,4 @@
-from .base import PrimitiveOperation, support_iterable
+from .base import PrimitiveOperation, handle_null, support_iterable
 from typing import Union
 
 class Scale(PrimitiveOperation):
@@ -25,6 +25,7 @@ class Scale(PrimitiveOperation):
         return output
 
     @support_iterable
+    @handle_null
     def transform(self, value: Union[int, float]) -> Union[int, float]:
         """
         Multiply the input value by the scaling factor.

--- a/src/harmonization_framework/primitives/substitute.py
+++ b/src/harmonization_framework/primitives/substitute.py
@@ -1,5 +1,5 @@
 import re
-from .base import PrimitiveOperation, support_iterable
+from .base import PrimitiveOperation, handle_null, support_iterable
 
 class Substitute(PrimitiveOperation):
     """
@@ -36,6 +36,7 @@ class Substitute(PrimitiveOperation):
         return output
 
     @support_iterable
+    @handle_null
     def transform(self, value: str) -> str:
         """
         Replace all regex matches in the input with the substitution string.

--- a/src/harmonization_framework/primitives/threshold.py
+++ b/src/harmonization_framework/primitives/threshold.py
@@ -1,4 +1,4 @@
-from .base import PrimitiveOperation, support_iterable
+from .base import PrimitiveOperation, handle_null, support_iterable
 from typing import Union
 
 class Threshold(PrimitiveOperation):
@@ -29,6 +29,7 @@ class Threshold(PrimitiveOperation):
         return output
 
     @support_iterable
+    @handle_null
     def transform(self, value: Union[int, float]) -> Union[int, float]:
         """
         Clamp the input value between lower and upper bounds.

--- a/src/harmonization_framework/primitives/truncate.py
+++ b/src/harmonization_framework/primitives/truncate.py
@@ -1,4 +1,4 @@
-from .base import PrimitiveOperation, support_iterable
+from .base import PrimitiveOperation, handle_null, support_iterable
 
 class Truncate(PrimitiveOperation):
     """
@@ -26,6 +26,7 @@ class Truncate(PrimitiveOperation):
         return output
 
     @support_iterable
+    @handle_null
     def transform(self, value: str) -> str:
         """
         Truncate the input string to the configured length.

--- a/src/harmonization_framework/primitives/units.py
+++ b/src/harmonization_framework/primitives/units.py
@@ -1,4 +1,4 @@
-from .base import PrimitiveOperation, support_iterable
+from .base import PrimitiveOperation, handle_null, support_iterable
 from typing import Union
 from enum import Enum
 
@@ -61,6 +61,7 @@ class ConvertUnits(PrimitiveOperation):
         return output
 
     @support_iterable
+    @handle_null
     def transform(self, value: Union[int, float]) -> Union[int, float]:
         """
         Convert the input value to the target unit.

--- a/tests/test_null_handling.py
+++ b/tests/test_null_handling.py
@@ -1,0 +1,226 @@
+"""
+Null-handling contract for the primitive layer.
+
+Scalar primitives decorated with @handle_null must pass `None`, `float NaN`,
+and `pd.NA` through unchanged. List-consuming primitives (Reduce, MapEach)
+must reject null elements rather than silently dropping or propagating them.
+"""
+
+import math
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from harmonization_framework.harmonization_rule import HarmonizationRule
+from harmonization_framework.harmonize import harmonize_dataset
+from harmonization_framework.primitives import (
+    Bin,
+    Cast,
+    ConvertDate,
+    ConvertUnits,
+    FormatNumber,
+    MapEach,
+    NormalizeText,
+    Offset,
+    Reduce,
+    Round,
+    Scale,
+    Substitute,
+    Threshold,
+    Truncate,
+    Unit,
+)
+from harmonization_framework.primitives.base import handle_null, isnull
+from harmonization_framework.primitives.normalize import Normalization
+from harmonization_framework.primitives.reduce import Reduction
+from harmonization_framework.rule_registry import RuleSet
+
+
+NULLS = [None, float("nan"), pd.NA]
+
+
+def _is_same_null(actual, expected):
+    """Helper: NaN != NaN, pd.NA != anything, so compare by category."""
+    if expected is None:
+        return actual is None
+    if isinstance(expected, float) and math.isnan(expected):
+        return isinstance(actual, float) and math.isnan(actual)
+    if expected is pd.NA:
+        return actual is pd.NA
+    return actual == expected
+
+
+# --- isnull() ----------------------------------------------------------------
+
+
+def test_isnull_recognises_none_nan_pdna():
+    assert isnull(None)
+    assert isnull(float("nan"))
+    assert isnull(np.nan)
+    assert isnull(pd.NA)
+
+
+def test_isnull_rejects_non_nulls():
+    assert not isnull(0)
+    assert not isnull("")
+    assert not isnull([])
+    assert not isnull(False)
+    assert not isnull("hello")
+    assert not isnull(3.14)
+
+
+# --- @handle_null decorator --------------------------------------------------
+
+
+def test_handle_null_passes_through_and_calls_underlying_only_for_non_null():
+    calls = []
+
+    class _Probe:
+        @handle_null
+        def transform(self, value):
+            calls.append(value)
+            return value * 2
+
+    probe = _Probe()
+    assert probe.transform(None) is None
+    assert math.isnan(probe.transform(float("nan")))
+    assert probe.transform(pd.NA) is pd.NA
+    assert probe.transform(3) == 6
+    # Underlying transform was only invoked for the non-null call.
+    assert calls == [3]
+
+
+# --- Scalar primitives pass nulls through ------------------------------------
+
+
+@pytest.mark.parametrize("null", NULLS)
+def test_scale_passes_null_through(null):
+    assert _is_same_null(Scale(2.0).transform(null), null)
+
+
+@pytest.mark.parametrize("null", NULLS)
+def test_offset_passes_null_through(null):
+    assert _is_same_null(Offset(3).transform(null), null)
+
+
+@pytest.mark.parametrize("null", NULLS)
+def test_round_passes_null_through(null):
+    assert _is_same_null(Round(2).transform(null), null)
+
+
+@pytest.mark.parametrize("null", NULLS)
+def test_threshold_passes_null_through(null):
+    assert _is_same_null(Threshold(0, 10).transform(null), null)
+
+
+@pytest.mark.parametrize("null", NULLS)
+def test_truncate_passes_null_through(null):
+    assert _is_same_null(Truncate(5).transform(null), null)
+
+
+@pytest.mark.parametrize("null", NULLS)
+def test_cast_passes_null_through(null):
+    # All cast targets must short-circuit on null.
+    for target in ("text", "integer", "boolean", "decimal", "float"):
+        assert _is_same_null(Cast("text", target).transform(null), null)
+
+
+@pytest.mark.parametrize("null", NULLS)
+def test_bin_passes_null_through(null):
+    primitive = Bin([("low", (0, 9)), ("high", (10, 19))])
+    assert _is_same_null(primitive.transform(null), null)
+
+
+@pytest.mark.parametrize("null", NULLS)
+def test_format_number_passes_null_through(null):
+    assert _is_same_null(FormatNumber(2).transform(null), null)
+
+
+@pytest.mark.parametrize("null", NULLS)
+def test_normalize_text_passes_null_through(null):
+    assert _is_same_null(NormalizeText(Normalization.LOWER).transform(null), null)
+
+
+@pytest.mark.parametrize("null", NULLS)
+def test_substitute_passes_null_through(null):
+    assert _is_same_null(Substitute(r"foo", "bar").transform(null), null)
+
+
+@pytest.mark.parametrize("null", NULLS)
+def test_convert_units_passes_null_through(null):
+    assert _is_same_null(ConvertUnits(Unit.KILOGRAM, Unit.POUNDS).transform(null), null)
+
+
+@pytest.mark.parametrize("null", NULLS)
+def test_convert_date_passes_null_through(null):
+    assert _is_same_null(ConvertDate("%Y-%m-%d", "%m/%d/%Y").transform(null), null)
+
+
+# --- support_iterable still passes nulls through inside a list ---------------
+
+
+def test_scale_list_with_nulls_returns_list_with_nulls_preserved():
+    out = Scale(2.0).transform([1, None, 3, float("nan"), 5])
+    assert out[0] == 2.0
+    assert out[1] is None
+    assert out[2] == 6.0
+    assert math.isnan(out[3])
+    assert out[4] == 10.0
+
+
+# --- Reduce rejects nulls ----------------------------------------------------
+
+
+def test_reduce_rejects_null_element():
+    with pytest.raises(ValueError, match="null value at position 1"):
+        Reduce(Reduction.SUM).transform([1, None, 3])
+
+
+def test_reduce_rejects_nan_element():
+    with pytest.raises(ValueError, match="null value at position 0"):
+        Reduce(Reduction.SUM).transform([float("nan"), 1, 2])
+
+
+def test_reduce_rejects_pdna_element():
+    with pytest.raises(ValueError, match="null value at position 2"):
+        Reduce(Reduction.ANY).transform([1, 0, pd.NA])
+
+
+# --- MapEach rejects nulls ---------------------------------------------------
+
+
+def test_map_each_rejects_null_element():
+    with pytest.raises(ValueError, match="null value at position 1"):
+        MapEach([Cast("text", "integer")]).transform(["1", None, "3"])
+
+
+def test_map_each_rejects_pdna_element():
+    with pytest.raises(ValueError, match="null value at position 0"):
+        MapEach([Offset(1)]).transform([pd.NA, 1, 2])
+
+
+# --- End-to-end: pandas DataFrame with NaN ----------------------------------
+
+
+def test_harmonize_dataset_does_not_crash_on_nan_inputs():
+    """The motivating real-world case: a CSV with blank cells lands as NaN
+    in pandas, and applying a rule chain should leave those rows as null
+    rather than raising."""
+    rules = RuleSet()
+    rules.add_rule(
+        HarmonizationRule(
+            ["weight_lbs"],
+            "weight_kg",
+            [Scale(0.453592), Round(2)],
+        )
+    )
+    df = pd.DataFrame({"weight_lbs": [100.0, float("nan"), 200.0, None]})
+
+    out = harmonize_dataset(df, rules, dataset_name="test")
+    values = out["weight_kg"].tolist()
+    assert values[0] == pytest.approx(45.36)
+    # Both NaN and None coming in survive as NaN/None on the way out.
+    assert isnull(values[1])
+    assert values[2] == pytest.approx(90.72)
+    assert isnull(values[3])


### PR DESCRIPTION
## Summary

Fixes the long-standing crash when primitives encounter missing values. Closes #25.

Before:

\`\`\`python
Scale(2.0).transform(None)              # TypeError: unsupported operand type
df[\"weight_lbs\"].apply(Scale(2.0).transform)  # crashes mid-apply on any NaN
\`\`\`

After: nulls pass through untouched.

\`\`\`python
Scale(2.0).transform(None)              # None
Scale(2.0).transform(float(\"nan\"))      # nan
Scale(2.0).transform(pd.NA)             # <NA>
\`\`\`

### Design

- **\`isnull(value)\` helper** in \`primitives/base.py\` — recognises \`None\`, float \`NaN\`, and \`pd.NA\`.
- **\`@handle_null\` decorator** — for scalar primitives whose transform expects a non-null value. The decorated method is never called for a null input; the null is returned as-is. Pairs with \`@support_iterable\` (outer-to-inner): a list flows through \`support_iterable\` first, then each element through \`handle_null\` before reaching the real transform. Decorator order is documented in the docstring.
- **Applied to 12 scalar primitives**: \`Bin\`, \`Cast\`, \`ConvertDate\`, \`ConvertUnits\`, \`FormatNumber\`, \`NormalizeText\`, \`Offset\`, \`Round\`, \`Scale\`, \`Substitute\`, \`Threshold\`, \`Truncate\`.
- **Not applied to \`EnumToEnum\` or \`NormalizeBoolean\`** — they already model missing values via \`strict\`/\`default\` parameters and their semantics shouldn't change.
- **\`Reduce\` and \`MapEach\` reject null elements** with a positional error message. The rationale is documented in their docstrings: a null inside a multi-source list usually means a source column is missing for that row, and silently dropping it is exactly the kind of quiet data corruption #25 warned about. The CLI's existing \`--on-missing\` policy continues to handle the whole-column case.

### Tests

\`tests/test_null_handling.py\` (46 new tests, all green):

- \`isnull\` semantics (recognised forms, rejected non-nulls)
- \`@handle_null\` only invokes the underlying transform for non-null values
- Every decorated primitive passes \`None\`, \`float('nan')\`, and \`pd.NA\` through unchanged (parameterised)
- Scale on a list containing nulls preserves the nulls in the output list
- \`Reduce\` and \`MapEach\` raise \`ValueError\` with the offending index for null elements
- End-to-end: \`harmonize_dataset\` on a pandas DataFrame containing \`NaN\` and \`None\` runs without crashing and yields nulls at the corresponding output positions

131 tests pass overall (was 85).

### Backwards compatibility

Purely additive — non-null inputs behave exactly as before. The behaviour of \`EnumToEnum\` and \`NormalizeBoolean\` (which were already null-aware) is unchanged.

## Test plan

- [x] \`pytest\` — 131/131 pass
- [x] \`demo/harmonize_example/run_example.py\` still runs end-to-end
- [ ] Reviewer to confirm the \"fail loudly on null in Reduce/MapEach\" choice; the alternative would be to silently skip nulls

🤖 Generated with [Claude Code](https://claude.com/claude-code)