### PR TITLE
Route library-internal warnings through logging (#15)

### DIFF
--- a/src/harmonization_framework/primitives/bin_primitive.py
+++ b/src/harmonization_framework/primitives/bin_primitive.py
@@ -1,5 +1,9 @@
-from .base import PrimitiveOperation, handle_null, support_iterable
+import logging
 from typing import Any, List, Tuple
+
+from .base import PrimitiveOperation, handle_null, support_iterable
+
+logger = logging.getLogger(__name__)
 
 class _IntervalNode:
     def __init__(self, label: Any, lower: int, upper: int, left=None, right=None):
@@ -39,7 +43,7 @@ class Bin(PrimitiveOperation):
     def transform(self, value: int) -> Any:
         transformed = self._query(value, self._tree)
         if transformed is None:
-            print(f"Warning: value={value} does not belong to a bin.")
+            logger.warning("Value %r does not belong to a bin.", value)
         return transformed
 
     def _query(self, value: int, node: _IntervalNode) -> Any:

--- a/src/harmonization_framework/primitives/enum2enum.py
+++ b/src/harmonization_framework/primitives/enum2enum.py
@@ -1,5 +1,9 @@
-from .base import PrimitiveOperation, support_iterable
+import logging
 from typing import Any, Dict
+
+from .base import PrimitiveOperation, support_iterable
+
+logger = logging.getLogger(__name__)
 
 class EnumToEnum(PrimitiveOperation):
     """
@@ -47,8 +51,7 @@ class EnumToEnum(PrimitiveOperation):
         if value not in self.mapping:
             if self.strict:
                 raise KeyError(f"Missing mapping for value: {value}")
-            # this should be a properly logged warning
-            print(f"Warning: value={value} does not have a defined mapping.")
+            logger.warning("Value %r does not have a defined mapping.", value)
             return self.default
         return self.mapping[value]
 

--- a/src/harmonization_framework/primitives/reduce.py
+++ b/src/harmonization_framework/primitives/reduce.py
@@ -1,6 +1,10 @@
-from .base import PrimitiveOperation, isnull
+import logging
 from enum import Enum
 from typing import Any, List
+
+from .base import PrimitiveOperation, isnull
+
+logger = logging.getLogger(__name__)
 
 class Reduction(Enum):
     # boolean operations, e.g., for one-hot conversions
@@ -84,12 +88,12 @@ class Reduce(PrimitiveOperation):
                 raise ValueError(f"One-hot reduction expects 0/1 values, got {value!r}")
         total = sum(values)
         if total != 1:
-            print(f"One-hot reduction error: sum = {total}")
+            logger.warning("One-hot reduction error: sum = %s", total)
             return None
         for i, value in enumerate(values):
             if value:
                 return i
-        print("One-hot reduction error: no flipped bit found")
+        logger.warning("One-hot reduction error: no flipped bit found")
         return None
 
     @classmethod

--- a/src/harmonization_framework/rule_registry.py
+++ b/src/harmonization_framework/rule_registry.py
@@ -1,8 +1,10 @@
+import json
+import logging
 from typing import Iterable, List
 
 from .harmonization_rule import HarmonizationRule
 
-import json
+logger = logging.getLogger(__name__)
 
 
 class RuleSet:
@@ -22,7 +24,7 @@ class RuleSet:
         """
         for i, existing in enumerate(self._rules):
             if existing.target == rule.target:
-                print(f"Warning: rule already exists for target {rule.target}; replacing.")
+                logger.warning("Rule already exists for target %s; replacing.", rule.target)
                 self._rules[i] = rule
                 return
         self._rules.append(rule)


### PR DESCRIPTION
## Summary

Closes #15. Library-internal warnings now use the \`logging\` module instead of \`print()\`, so they no longer pollute stdout (which matters because the CLI streams harmonized CSV through stdout when piped) and can be filtered by severity.

Five call sites changed to \`logger.warning(...)\`:

- \`RuleSet.add_rule\` — duplicate-target warning
- \`Bin.transform\` — value outside any bin
- \`EnumToEnum.transform\` — missing mapping in non-strict mode
- \`Reduce.onehot_reduction\` — two error paths

Each module declares \`logger = logging.getLogger(__name__)\` at top level, so callers can configure or suppress these warnings per-module if they want.

### Deliberately left as \`print()\`

- \`cli.py\` — \`Warning: skipping missing source columns: ...\` (user-facing CLI output)
- \`harmonize.py\` — \`Applying rule -> target (sources: [...])\` (user-facing progress output)

Those are direct CLI ergonomics, not library logging events.

## Test plan

- [x] All 131 tests still pass
- [x] CLI behaviour unchanged — \`test_cli_missing_behavior\` still captures the warning message it expects

🤖 Generated with [Claude Code](https://claude.com/claude-code)