### PR TITLE
Add extract_regex and validate_pattern primitives (#100, #101)

### DIFF
--- a/src/harmonization_framework/primitives/__init__.py
+++ b/src/harmonization_framework/primitives/__init__.py
@@ -4,6 +4,7 @@ from .cast import Cast
 from .dates import ConvertDate
 from .donothing import DoNothing
 from .enum2enum import EnumToEnum
+from .extract_regex import ExtractRegex
 from .format_number import FormatNumber
 from .map_each import MapEach
 from .normalize_boolean import NormalizeBoolean
@@ -17,4 +18,5 @@ from .substitute import Substitute
 from .threshold import Threshold
 from .truncate import Truncate
 from .units import ConvertUnits, Unit
+from .validate_pattern import ValidatePattern
 from .vocabulary import PrimitiveVocabulary

--- a/src/harmonization_framework/primitives/extract_regex.py
+++ b/src/harmonization_framework/primitives/extract_regex.py
@@ -1,0 +1,109 @@
+import re
+from typing import Any, Iterable, List, Optional, Union
+
+from .base import PrimitiveOperation, handle_null, support_iterable
+
+
+# Whitelist the regex flags we accept in serialization. Limited on purpose so
+# the serialized form stays portable and reviewable.
+_FLAG_NAMES = {
+    "IGNORECASE": re.IGNORECASE,
+    "MULTILINE": re.MULTILINE,
+    "DOTALL": re.DOTALL,
+}
+
+
+def _resolve_flags(flag_names: Optional[Iterable[str]]) -> int:
+    """Combine a list of flag names into an `re` flags bitmask."""
+    if not flag_names:
+        return 0
+    bitmask = 0
+    for name in flag_names:
+        if name not in _FLAG_NAMES:
+            raise ValueError(
+                f"Unsupported regex flag: {name!r}. "
+                f"Supported: {sorted(_FLAG_NAMES)}"
+            )
+        bitmask |= _FLAG_NAMES[name]
+    return bitmask
+
+
+class ExtractRegex(PrimitiveOperation):
+    """
+    Extract a value from a string using a regex capture group.
+
+    Common harmonization use cases include pulling identifiers out of free
+    text (e.g., MRN: A12-99) or numeric suffixes out of structured codes.
+    """
+
+    def __init__(
+        self,
+        expression: str,
+        group: Union[int, str] = 1,
+        flags: Optional[List[str]] = None,
+        strict: bool = True,
+        default: Any = None,
+    ):
+        if not isinstance(group, (int, str)):
+            raise TypeError(
+                f"group must be an int or str, got {type(group).__name__}"
+            )
+        if isinstance(group, int) and group < 0:
+            raise ValueError(f"group index must be non-negative, got {group}")
+
+        self.flags = list(flags) if flags else []
+        try:
+            self._pattern = re.compile(expression, _resolve_flags(self.flags))
+        except re.error as exc:
+            raise ValueError(f"Invalid regex pattern: {expression!r}") from exc
+
+        self.expression = expression
+        self.group = group
+        self.strict = strict
+        self.default = default
+
+    def __str__(self):
+        return f"Extract group {self.group!r} from regex {self.expression!r}"
+
+    def to_dict(self):
+        output = {
+            "operation": "extract_regex",
+            "expression": self.expression,
+            "group": self.group,
+            "strict": self.strict,
+        }
+        if self.flags:
+            output["flags"] = list(self.flags)
+        if self.default is not None:
+            output["default"] = self.default
+        return output
+
+    @support_iterable
+    @handle_null
+    def transform(self, value: str) -> Any:
+        match = self._pattern.search(value)
+        if match is None:
+            if self.strict:
+                raise ValueError(
+                    f"Pattern {self.expression!r} did not match value {value!r}"
+                )
+            return self.default
+        try:
+            return match.group(self.group)
+        except (IndexError, re.error) as exc:
+            if self.strict:
+                raise ValueError(
+                    f"Group {self.group!r} not found in match of {self.expression!r} "
+                    f"against value {value!r}"
+                ) from exc
+            return self.default
+
+    @classmethod
+    def from_serialization(cls, serialization):
+        return ExtractRegex(
+            expression=serialization["expression"],
+            group=serialization.get("group", 1),
+            flags=serialization.get("flags"),
+            strict=bool(serialization.get("strict", True)),
+            default=serialization.get("default"),
+        )

--- a/src/harmonization_framework/primitives/factory.py
+++ b/src/harmonization_framework/primitives/factory.py
@@ -15,6 +15,7 @@ from .cast import Cast
 from .dates import ConvertDate
 from .donothing import DoNothing
 from .enum2enum import EnumToEnum
+from .extract_regex import ExtractRegex
 from .format_number import FormatNumber
 from .map_each import MapEach
 from .normalize import NormalizeText
@@ -28,6 +29,7 @@ from .substitute import Substitute
 from .threshold import Threshold
 from .truncate import Truncate
 from .units import ConvertUnits
+from .validate_pattern import ValidatePattern
 from .vocabulary import PrimitiveVocabulary
 
 
@@ -51,6 +53,8 @@ def deserialize_operation(operation: Dict[str, Any]) -> PrimitiveOperation:
             return DoNothing.from_serialization(operation)
         case PrimitiveVocabulary.ENUM_TO_ENUM.value:
             return EnumToEnum.from_serialization(operation)
+        case PrimitiveVocabulary.EXTRACT_REGEX.value:
+            return ExtractRegex.from_serialization(operation)
         case PrimitiveVocabulary.FORMAT_NUMBER.value:
             return FormatNumber.from_serialization(operation)
         case PrimitiveVocabulary.MAP_EACH.value:
@@ -75,5 +79,7 @@ def deserialize_operation(operation: Dict[str, Any]) -> PrimitiveOperation:
             return Threshold.from_serialization(operation)
         case PrimitiveVocabulary.TRUNCATE.value:
             return Truncate.from_serialization(operation)
+        case PrimitiveVocabulary.VALIDATE_PATTERN.value:
+            return ValidatePattern.from_serialization(operation)
         case _:
             raise ValueError(f"Unknown operation: {name}")

--- a/src/harmonization_framework/primitives/validate_pattern.py
+++ b/src/harmonization_framework/primitives/validate_pattern.py
@@ -1,0 +1,87 @@
+import re
+from typing import Any, List, Optional
+
+from .base import PrimitiveOperation, handle_null, support_iterable
+from .extract_regex import _resolve_flags
+
+
+_VALID_MODES = {"match", "fullmatch", "search"}
+
+
+class ValidatePattern(PrimitiveOperation):
+    """
+    Assert that a string matches a regex pattern.
+
+    Returns the original value on success. On failure: raises `ValueError`
+    if `strict=True`, else returns `default`. Use as a data-quality gate in
+    a rule chain.
+    """
+
+    def __init__(
+        self,
+        expression: str,
+        flags: Optional[List[str]] = None,
+        mode: str = "match",
+        strict: bool = True,
+        default: Any = None,
+    ):
+        if mode not in _VALID_MODES:
+            raise ValueError(
+                f"Unsupported mode {mode!r}. Supported: {sorted(_VALID_MODES)}"
+            )
+
+        self.flags = list(flags) if flags else []
+        try:
+            self._pattern = re.compile(expression, _resolve_flags(self.flags))
+        except re.error as exc:
+            raise ValueError(f"Invalid regex pattern: {expression!r}") from exc
+
+        self.expression = expression
+        self.mode = mode
+        self.strict = strict
+        self.default = default
+
+    def __str__(self):
+        return f"Validate value against regex {self.expression!r} ({self.mode})"
+
+    def to_dict(self):
+        output = {
+            "operation": "validate_pattern",
+            "expression": self.expression,
+            "mode": self.mode,
+            "strict": self.strict,
+        }
+        if self.flags:
+            output["flags"] = list(self.flags)
+        if self.default is not None:
+            output["default"] = self.default
+        return output
+
+    @support_iterable
+    @handle_null
+    def transform(self, value: str) -> Any:
+        if self._is_valid(value):
+            return value
+        if self.strict:
+            raise ValueError(
+                f"Value {value!r} does not match pattern {self.expression!r} "
+                f"(mode={self.mode})"
+            )
+        return self.default
+
+    def _is_valid(self, value: str) -> bool:
+        if self.mode == "match":
+            return self._pattern.match(value) is not None
+        if self.mode == "fullmatch":
+            return self._pattern.fullmatch(value) is not None
+        return self._pattern.search(value) is not None
+
+    @classmethod
+    def from_serialization(cls, serialization):
+        return ValidatePattern(
+            expression=serialization["expression"],
+            flags=serialization.get("flags"),
+            mode=serialization.get("mode", "match"),
+            strict=bool(serialization.get("strict", True)),
+            default=serialization.get("default"),
+        )

--- a/src/harmonization_framework/primitives/vocabulary.py
+++ b/src/harmonization_framework/primitives/vocabulary.py
@@ -7,6 +7,7 @@ class PrimitiveVocabulary(Enum):
     CONVERT_UNITS = "convert_units"
     DO_NOTHING = "do_nothing"
     ENUM_TO_ENUM = "enum_to_enum"
+    EXTRACT_REGEX = "extract_regex"
     FORMAT_NUMBER = "format_number"
     MAP_EACH = "map_each"
     NORMALIZE_BOOLEAN = "normalize_boolean"
@@ -19,3 +20,4 @@ class PrimitiveVocabulary(Enum):
     SUBSTITUTE = "substitute"
     THRESHOLD = "threshold"
     TRUNCATE = "truncate"
+    VALIDATE_PATTERN = "validate_pattern"

--- a/tests/test_regex_primitives.py
+++ b/tests/test_regex_primitives.py
@@ -1,0 +1,234 @@
+"""Tests for ExtractRegex (#100) and ValidatePattern (#101)."""
+
+import pytest
+
+from harmonization_framework.harmonization_rule import HarmonizationRule
+from harmonization_framework.primitives import ExtractRegex, ValidatePattern
+
+
+# -----------------------------------------------------------------------------
+# ExtractRegex
+# -----------------------------------------------------------------------------
+
+
+def test_extract_regex_basic_numeric_group():
+    primitive = ExtractRegex(r"MRN[:\s]+([A-Z0-9-]+)")
+    assert primitive.transform("Patient MRN: A12-99") == "A12-99"
+
+
+def test_extract_regex_explicit_group_index():
+    primitive = ExtractRegex(r"visit_(\d+)", group=1)
+    assert primitive.transform("visit_0042") == "0042"
+
+
+def test_extract_regex_named_group():
+    primitive = ExtractRegex(r"(?P<id>[A-Z]+\d+)", group="id")
+    assert primitive.transform("see record AB123 today") == "AB123"
+
+
+def test_extract_regex_group_zero_returns_full_match():
+    primitive = ExtractRegex(r"\d+", group=0)
+    assert primitive.transform("answer is 42 today") == "42"
+
+
+def test_extract_regex_no_match_strict_raises():
+    primitive = ExtractRegex(r"\d+", strict=True)
+    with pytest.raises(ValueError, match="did not match"):
+        primitive.transform("no digits here")
+
+
+def test_extract_regex_no_match_non_strict_returns_default():
+    primitive = ExtractRegex(r"\d+", strict=False, default="UNKNOWN")
+    assert primitive.transform("no digits here") == "UNKNOWN"
+
+
+def test_extract_regex_invalid_group_strict_raises():
+    primitive = ExtractRegex(r"(\d+)", group=5, strict=True)
+    with pytest.raises(ValueError, match="Group .* not found"):
+        primitive.transform("matches 42 here")
+
+
+def test_extract_regex_invalid_group_non_strict_returns_default():
+    primitive = ExtractRegex(r"(\d+)", group=5, strict=False, default=None)
+    assert primitive.transform("matches 42 here") is None
+
+
+def test_extract_regex_iterable_input():
+    primitive = ExtractRegex(r"(\d+)")
+    assert primitive.transform(["a1", "b22", "c333"]) == ["1", "22", "333"]
+
+
+def test_extract_regex_flags():
+    primitive = ExtractRegex(r"([A-Z]+)", flags=["IGNORECASE"])
+    assert primitive.transform("hello") == "hello"
+
+
+def test_extract_regex_rejects_invalid_pattern():
+    with pytest.raises(ValueError, match="Invalid regex pattern"):
+        ExtractRegex(r"[")
+
+
+def test_extract_regex_rejects_unknown_flag():
+    with pytest.raises(ValueError, match="Unsupported regex flag"):
+        ExtractRegex(r"\d+", flags=["VERBOSE"])
+
+
+def test_extract_regex_rejects_negative_group_index():
+    with pytest.raises(ValueError, match="non-negative"):
+        ExtractRegex(r"(\d+)", group=-1)
+
+
+def test_extract_regex_serialization_roundtrip():
+    primitive = ExtractRegex(
+        r"MRN[:\s]+([A-Z0-9-]+)",
+        group=1,
+        strict=False,
+        default="UNK",
+    )
+    payload = primitive.to_dict()
+    assert payload == {
+        "operation": "extract_regex",
+        "expression": r"MRN[:\s]+([A-Z0-9-]+)",
+        "group": 1,
+        "strict": False,
+        "default": "UNK",
+    }
+    roundtrip = ExtractRegex.from_serialization(payload)
+    assert roundtrip.to_dict() == payload
+    assert roundtrip.transform("MRN: A12-99") == "A12-99"
+
+
+def test_extract_regex_serialization_includes_flags_when_set():
+    primitive = ExtractRegex(r"([a-z]+)", flags=["IGNORECASE", "MULTILINE"])
+    payload = primitive.to_dict()
+    assert payload["flags"] == ["IGNORECASE", "MULTILINE"]
+    roundtrip = ExtractRegex.from_serialization(payload)
+    assert roundtrip.transform("HELLO") == "HELLO"
+
+
+def test_extract_regex_passes_null_through():
+    primitive = ExtractRegex(r"\d+")
+    assert primitive.transform(None) is None
+
+
+def test_extract_regex_in_rule_chain():
+    rule = HarmonizationRule(
+        ["raw_id"],
+        "extracted_id",
+        [ExtractRegex(r"ID:(\w+)", group=1)],
+    )
+    roundtrip = HarmonizationRule.from_serialization(rule.serialize())
+    assert roundtrip.transform("ID:ABC123") == "ABC123"
+
+
+# -----------------------------------------------------------------------------
+# ValidatePattern
+# -----------------------------------------------------------------------------
+
+
+def test_validate_pattern_returns_value_when_valid_default_match():
+    primitive = ValidatePattern(r"[A-Z]{2}\d{6}")
+    assert primitive.transform("AB123456") == "AB123456"
+
+
+def test_validate_pattern_strict_failure_raises():
+    primitive = ValidatePattern(r"^[A-Z]{2}\d{6}$", mode="fullmatch")
+    with pytest.raises(ValueError, match="does not match"):
+        primitive.transform("AB12345")
+
+
+def test_validate_pattern_non_strict_failure_returns_default():
+    primitive = ValidatePattern(
+        r"^[A-Z]{2}\d{6}$",
+        mode="fullmatch",
+        strict=False,
+        default=None,
+    )
+    assert primitive.transform("invalid") is None
+
+
+def test_validate_pattern_match_mode_anchors_at_start_only():
+    # 'match' only requires anchoring at the start; trailing text is OK.
+    primitive = ValidatePattern(r"[A-Z]{2}", mode="match")
+    assert primitive.transform("AB-extra") == "AB-extra"
+    with pytest.raises(ValueError):
+        primitive.transform("-AB")
+
+
+def test_validate_pattern_fullmatch_mode_anchors_both_ends():
+    primitive = ValidatePattern(r"[A-Z]{2}", mode="fullmatch")
+    assert primitive.transform("AB") == "AB"
+    with pytest.raises(ValueError):
+        primitive.transform("ABC")
+
+
+def test_validate_pattern_search_mode_matches_anywhere():
+    primitive = ValidatePattern(r"\d+", mode="search")
+    assert primitive.transform("the answer is 42") == "the answer is 42"
+    with pytest.raises(ValueError):
+        primitive.transform("no digits")
+
+
+def test_validate_pattern_iterable_input():
+    primitive = ValidatePattern(r"^[A-Z]{2}$", mode="fullmatch")
+    assert primitive.transform(["AB", "CD"]) == ["AB", "CD"]
+
+
+def test_validate_pattern_iterable_strict_failure_propagates():
+    primitive = ValidatePattern(r"^[A-Z]{2}$", mode="fullmatch")
+    with pytest.raises(ValueError, match="does not match"):
+        primitive.transform(["AB", "abc"])
+
+
+def test_validate_pattern_rejects_invalid_pattern():
+    with pytest.raises(ValueError, match="Invalid regex pattern"):
+        ValidatePattern(r"[")
+
+
+def test_validate_pattern_rejects_invalid_mode():
+    with pytest.raises(ValueError, match="Unsupported mode"):
+        ValidatePattern(r"\d+", mode="weird")
+
+
+def test_validate_pattern_rejects_unknown_flag():
+    with pytest.raises(ValueError, match="Unsupported regex flag"):
+        ValidatePattern(r"\d+", flags=["WHATEVER"])
+
+
+def test_validate_pattern_serialization_roundtrip():
+    primitive = ValidatePattern(
+        r"^[A-Z]{2}\d{6}$",
+        flags=["IGNORECASE"],
+        mode="fullmatch",
+        strict=False,
+        default="INVALID",
+    )
+    payload = primitive.to_dict()
+    assert payload == {
+        "operation": "validate_pattern",
+        "expression": r"^[A-Z]{2}\d{6}$",
+        "mode": "fullmatch",
+        "strict": False,
+        "flags": ["IGNORECASE"],
+        "default": "INVALID",
+    }
+    roundtrip = ValidatePattern.from_serialization(payload)
+    assert roundtrip.to_dict() == payload
+    assert roundtrip.transform("ab123456") == "ab123456"
+
+
+def test_validate_pattern_passes_null_through():
+    primitive = ValidatePattern(r"^[A-Z]+$", mode="fullmatch")
+    assert primitive.transform(None) is None
+
+
+def test_validate_pattern_in_rule_chain():
+    rule = HarmonizationRule(
+        ["id"],
+        "validated_id",
+        [ValidatePattern(r"^[A-Z]{2}\d{6}$", mode="fullmatch")],
+    )
+    roundtrip = HarmonizationRule.from_serialization(rule.serialize())
+    assert roundtrip.transform("AB123456") == "AB123456"
+    with pytest.raises(ValueError):
+        roundtrip.transform("nope")


### PR DESCRIPTION
## Summary

Adds two regex-based primitives — `extract_regex` and `validate_pattern` — paired in one PR because they share infrastructure (flag whitelist, null-handling decorator, factory wiring) and the same test patterns. Closes #100 and #101.

### `extract_regex` (#100)
Pulls a capture group out of a string. Supports positional or named groups, optional regex flags from a whitelisted set (`IGNORECASE`, `MULTILINE`, `DOTALL`), and the standard `strict`/`default` fallback pattern.

```json
{
  "operation": "extract_regex",
  "expression": "MRN[:\\\\s]+([A-Z0-9-]+)",
  "group": 1,
  "strict": true
}
```

```python
ExtractRegex(r"MRN[:\\s]+([A-Z0-9-]+)").transform("Patient MRN: A12-99")
# => "A12-99"
```

### `validate_pattern` (#101)
Asserts that a value matches a regex; returns the original value on success, or raises (strict) / returns `default` (non-strict) on failure. Configurable mode picks the anchoring semantics:

- `match` — anchored at start (default)
- `fullmatch` — anchored both ends
- `search` — match anywhere

```json
{
  "operation": "validate_pattern",
  "expression": "^[A-Z]{2}\\\\d{6}$",
  "mode": "fullmatch",
  "strict": true
}
```

### Design notes
- Patterns compile eagerly at construction time so a malformed regex fails fast rather than per-row.
- Flags are a whitelisted set (rejects unknown names like `VERBOSE`) so the serialized form stays portable and reviewable.
- Both primitives wear `@handle_null` + `@support_iterable`, consistent with the other string primitives — nulls pass through unchanged, lists fan out per element.
- `validate_pattern` deliberately reuses `extract_regex`'s flag resolver to keep the two primitives in lockstep on the supported flag vocabulary.

### Tests
31 new tests in `tests/test_regex_primitives.py` covering every bullet in the issues' test plans: basic / named-group / explicit-index extraction, full-match group 0, strict + non-strict failure paths, invalid group, iterable input, flags, invalid pattern, unknown flag, all three validate modes, serialization roundtrip with and without flags, null pass-through, and a HarmonizationRule chain that goes through serialization on both primitives.

Total: 162 tests pass (was 131).

## Test plan

- [x] `pytest` — 162/162 pass
- [x] Spec items from each issue's V1 behaviour and test-plan sections are covered by new tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)