### PR TITLE
Add MissingCode primitive + lossless mapping serialization

### DIFF
--- a/src/harmonization_framework/harmonize.py
+++ b/src/harmonization_framework/harmonize.py
@@ -5,6 +5,8 @@ from typing import Callable, Optional
 
 from .rule_registry import RuleSet
 from .replay_log import replay_logger as rlog
+from .primitives.base import isnull
+from .primitives.missing_code import MissingCode
 
 
 def harmonize_dataset(
@@ -56,9 +58,38 @@ def harmonize_dataset(
             transform_with_progress, axis=1
         )
 
+        if logger:
+            _log_missing_code_hits(logger, rule, dataset, dataset_name)
+
     dataset_harmonized["source dataset"] = [dataset_name] * len(dataset)
     dataset_harmonized["original_id"] = dataset.index.to_list()
     return dataset_harmonized
+
+
+def _log_missing_code_hits(logger, rule, dataset, dataset_name):
+    """
+    Report which source cells a rule's MissingCode primitive(s) nulled.
+
+    Correlation to rows is done by re-scanning the (single) source column rather
+    than by threading per-row state through `transform` — the membership test
+    here mirrors `MissingCode.transform` exactly. This is accurate only because
+    MissingCode is intended as the first primitive in a chain, operating on the
+    raw source value; see its docstring.
+    """
+    missing_code_ops = [op for op in (rule._transform or []) if isinstance(op, MissingCode)]
+    if not missing_code_ops or not rule.sources:
+        return
+
+    source_column = dataset[rule.sources[0]]
+    for op in missing_code_ops:
+        hits = []
+        for row_index, value in source_column.items():
+            if isnull(value):
+                continue
+            if value in op.codes:
+                hits.append((row_index, value, op.codes[value]))
+        if hits:
+            rlog.log_missing_code_hits(logger, rule, dataset_name, hits)
 
 
 def harmonize_file(

--- a/src/harmonization_framework/primitives/__init__.py
+++ b/src/harmonization_framework/primitives/__init__.py
@@ -7,6 +7,7 @@ from .enum2enum import EnumToEnum
 from .extract_regex import ExtractRegex
 from .format_number import FormatNumber
 from .map_each import MapEach
+from .missing_code import MissingCode
 from .normalize_boolean import NormalizeBoolean
 from .normalize import NormalizeText
 from .offset import Offset

--- a/src/harmonization_framework/primitives/enum2enum.py
+++ b/src/harmonization_framework/primitives/enum2enum.py
@@ -33,10 +33,17 @@ class EnumToEnum(PrimitiveOperation):
     def to_dict(self):
         """
         Serialize this mapping to a JSON-friendly dict.
+
+        The mapping is serialized as a LIST of {"from", "to"} entries rather than
+        a JSON object. JSON object keys are always strings, so an object form
+        would silently coerce non-string keys (e.g. the integer index emitted by
+        Reduce(ONEHOT)) to strings on a round-trip, breaking the lookup. The
+        entry-list keeps each key in a value position, preserving its native JSON
+        type (int stays int, float stays float, str stays str).
         """
         output = {
             "operation": "enum_to_enum",
-            "mapping": self.mapping,
+            "mapping": [{"from": key, "to": value} for key, value in self.mapping.items()],
             "strict": self.strict,
         }
         if self.default is not None:
@@ -59,21 +66,12 @@ class EnumToEnum(PrimitiveOperation):
     def from_serialization(cls, serialization):
         """
         Reconstruct an EnumToEnum mapping from a serialized dict.
+
+        `mapping` is a list of {"from", "to"} entries (see `to_dict`). Each key
+        and value is read back at its native JSON type, so no key-type coercion
+        is needed — int keys stay int, str keys stay str.
         """
-        mapping = serialization["mapping"]
-
-        def is_int_like(value: Any) -> bool:
-            if isinstance(value, bool):
-                return False
-            if isinstance(value, int):
-                return True
-            if isinstance(value, str):
-                stripped = value.strip()
-                return stripped.lstrip("-").isdigit() and stripped != ""
-            return False
-
-        if mapping and all(is_int_like(k) for k in mapping) and all(is_int_like(v) for v in mapping.values()):
-            mapping = {int(key): int(value) for key, value in mapping.items()}
+        mapping = {entry["from"]: entry["to"] for entry in serialization["mapping"]}
         default = serialization.get("default")
         strict = bool(serialization.get("strict", False))
         return EnumToEnum(mapping, default=default, strict=strict)

--- a/src/harmonization_framework/primitives/factory.py
+++ b/src/harmonization_framework/primitives/factory.py
@@ -18,6 +18,7 @@ from .enum2enum import EnumToEnum
 from .extract_regex import ExtractRegex
 from .format_number import FormatNumber
 from .map_each import MapEach
+from .missing_code import MissingCode
 from .normalize import NormalizeText
 from .normalize_boolean import NormalizeBoolean
 from .offset import Offset
@@ -59,6 +60,8 @@ def deserialize_operation(operation: Dict[str, Any]) -> PrimitiveOperation:
             return FormatNumber.from_serialization(operation)
         case PrimitiveVocabulary.MAP_EACH.value:
             return MapEach.from_serialization(operation)
+        case PrimitiveVocabulary.MISSING_CODE.value:
+            return MissingCode.from_serialization(operation)
         case PrimitiveVocabulary.NORMALIZE_BOOLEAN.value:
             return NormalizeBoolean.from_serialization(operation)
         case PrimitiveVocabulary.NORMALIZE_TEXT.value:

--- a/src/harmonization_framework/primitives/missing_code.py
+++ b/src/harmonization_framework/primitives/missing_code.py
@@ -53,12 +53,16 @@ class MissingCode(PrimitiveOperation):
         """
         Serialize this operation to a JSON-friendly dict.
 
-        Always emits the normalized {code: label} dict form, so a MissingCode
-        built from a bare list round-trips identically to one built from a dict.
+        Codes are serialized as a LIST of {"code", "label"} entries rather than a
+        JSON object. JSON object keys are always strings, so an object form would
+        coerce a numeric code (e.g. -999) to the string "-999" on a round-trip
+        and the lookup would then miss. The entry-list keeps each code in a value
+        position, preserving its native JSON type. A MissingCode built from a
+        bare list round-trips identically to one built from a dict.
         """
         return {
             "operation": "missing_code",
-            "codes": self.codes,
+            "codes": [{"code": code, "label": label} for code, label in self.codes.items()],
         }
 
     @support_iterable
@@ -81,44 +85,9 @@ class MissingCode(PrimitiveOperation):
         """
         Reconstruct a MissingCode operation from a serialized dict.
 
-        JSON object keys are always strings, so an integer code like -999 or a
-        float code like -999.0 round-trips as the string "-999"/"-999.0" and
-        would no longer match a numeric input. Mirror EnumToEnum's coercion:
-        restore int-like keys to int and float-like keys to float so lookups
-        match identically in-memory and after a rules.json round-trip. Labels
-        (values) are left untouched.
+        `codes` is a list of {"code", "label"} entries (see `to_dict`). Each code
+        is read back at its native JSON type, so a numeric code stays numeric —
+        no key-type coercion is needed.
         """
-        codes = serialization["codes"]
-
-        def is_int_like(value: Any) -> bool:
-            if isinstance(value, bool):
-                return False
-            if isinstance(value, int):
-                return True
-            if isinstance(value, str):
-                stripped = value.strip()
-                return stripped.lstrip("-").isdigit() and stripped != ""
-            return False
-
-        def is_float_like(value: Any) -> bool:
-            if isinstance(value, bool):
-                return False
-            if isinstance(value, (int, float)):
-                return True
-            if isinstance(value, str):
-                try:
-                    float(value)
-                    return True
-                except ValueError:
-                    return False
-            return False
-
-        def coerce_key(key: Any) -> Any:
-            if is_int_like(key):
-                return int(key)
-            if is_float_like(key):
-                return float(key)
-            return key
-
-        coerced = {coerce_key(key): value for key, value in codes.items()}
-        return MissingCode(coerced)
+        codes = {entry["code"]: entry["label"] for entry in serialization["codes"]}
+        return MissingCode(codes)

--- a/src/harmonization_framework/primitives/missing_code.py
+++ b/src/harmonization_framework/primitives/missing_code.py
@@ -1,0 +1,124 @@
+from typing import Any, Dict, List, Union
+
+from .base import PrimitiveOperation, isnull, support_iterable
+
+
+class MissingCode(PrimitiveOperation):
+    """
+    Operator that turns a column's missing-value codes into real nulls.
+
+    Real datasets frequently encode "missing" as an in-band sentinel value — a
+    numeric code like -999 or a token like "UNK" — rather than as an empty cell.
+    Such a code is an ordinary value to pandas: it survives every transform and
+    corrupts results. This primitive recognises a declared set of codes and maps
+    each to a genuine null (None), while passing all other values — including
+    real nulls — through unchanged. It is the identity-preserving null map that
+    EnumToEnum cannot express (EnumToEnum sends unmapped values to its default).
+
+    Codes carry a human label describing what the code means ("not_measured",
+    "refused", …). The labels are not emitted into the output column (a null has
+    no room for a reason); instead the harmonize engine reports each nulled cell,
+    with its label and row index, to the replay log. The labels are also recorded
+    in `rules.json` via `to_dict`, so the ruleset documents what each code means.
+
+    Intended placement: MissingCode should be the FIRST primitive in a rule's
+    transformation chain, because it operates on the raw source value and the
+    engine re-scans the raw source column to report hits. Putting a value-
+    altering primitive before it would desynchronise the report from the data.
+
+    Args:
+        codes: Either a list of codes (`[-999, -1]`, each labelled "missing") or
+            a dict mapping code -> label (`{-999: "not_measured"}`). Normalised
+            to a dict internally.
+    """
+
+    DEFAULT_LABEL = "missing"
+
+    def __init__(self, codes: Union[List[Any], Dict[Any, str]]):
+        if isinstance(codes, dict):
+            normalized = dict(codes)
+        elif isinstance(codes, (list, tuple, set)):
+            normalized = {code: self.DEFAULT_LABEL for code in codes}
+        else:
+            raise TypeError("MissingCode codes must be a list or a dict")
+        if not normalized:
+            raise ValueError("MissingCode requires at least one code")
+        self.codes = normalized
+
+    def __str__(self):
+        items = [f"  {code}->null ({label})" for code, label in self.codes.items()]
+        return "Missing-value codes:\n" + "\n".join(items)
+
+    def to_dict(self):
+        """
+        Serialize this operation to a JSON-friendly dict.
+
+        Always emits the normalized {code: label} dict form, so a MissingCode
+        built from a bare list round-trips identically to one built from a dict.
+        """
+        return {
+            "operation": "missing_code",
+            "codes": self.codes,
+        }
+
+    @support_iterable
+    def transform(self, value: Any) -> Any:
+        """
+        Map a declared missing-value code to None; pass everything else through.
+
+        A genuine null is passed through unchanged (it is already missing and is
+        never treated as a code). Any value matching a declared code becomes
+        None. All other values are returned unchanged — the identity branch.
+        """
+        if isnull(value):
+            return value
+        if value in self.codes:
+            return None
+        return value
+
+    @classmethod
+    def from_serialization(cls, serialization):
+        """
+        Reconstruct a MissingCode operation from a serialized dict.
+
+        JSON object keys are always strings, so an integer code like -999 or a
+        float code like -999.0 round-trips as the string "-999"/"-999.0" and
+        would no longer match a numeric input. Mirror EnumToEnum's coercion:
+        restore int-like keys to int and float-like keys to float so lookups
+        match identically in-memory and after a rules.json round-trip. Labels
+        (values) are left untouched.
+        """
+        codes = serialization["codes"]
+
+        def is_int_like(value: Any) -> bool:
+            if isinstance(value, bool):
+                return False
+            if isinstance(value, int):
+                return True
+            if isinstance(value, str):
+                stripped = value.strip()
+                return stripped.lstrip("-").isdigit() and stripped != ""
+            return False
+
+        def is_float_like(value: Any) -> bool:
+            if isinstance(value, bool):
+                return False
+            if isinstance(value, (int, float)):
+                return True
+            if isinstance(value, str):
+                try:
+                    float(value)
+                    return True
+                except ValueError:
+                    return False
+            return False
+
+        def coerce_key(key: Any) -> Any:
+            if is_int_like(key):
+                return int(key)
+            if is_float_like(key):
+                return float(key)
+            return key
+
+        coerced = {coerce_key(key): value for key, value in codes.items()}
+        return MissingCode(coerced)

--- a/src/harmonization_framework/primitives/vocabulary.py
+++ b/src/harmonization_framework/primitives/vocabulary.py
@@ -10,6 +10,7 @@ class PrimitiveVocabulary(Enum):
     EXTRACT_REGEX = "extract_regex"
     FORMAT_NUMBER = "format_number"
     MAP_EACH = "map_each"
+    MISSING_CODE = "missing_code"
     NORMALIZE_BOOLEAN = "normalize_boolean"
     NORMALIZE_TEXT = "normalize_text"
     OFFSET = "offset"

--- a/src/harmonization_framework/replay_log/replay_logger.py
+++ b/src/harmonization_framework/replay_log/replay_logger.py
@@ -14,10 +14,13 @@ class Event:
 
         Returns:
             dict with keys:
+            - event: "rule" — discriminates a replayable rule event from the
+              per-value audit events (e.g. missing_code) that also share the log
             - action: serialized harmonization rule
             - dataset: dataset identifier
         """
         log = {
+            "event": "rule",
             "action": self.action.serialize(),
             "dataset": self.dataset,
         }
@@ -87,3 +90,32 @@ def log_operation(logger, action, dataset):
     """
     event = Event(action, dataset)
     logger.info(json.dumps(event.to_log()))
+
+
+def log_missing_code_hits(logger, rule, dataset, hits):
+    """
+    Log one per-value audit event for each missing-value code that was nulled.
+
+    These are NOT replayable rule events — they record, for the audit trail,
+    which source cells matched a declared missing-value code and were turned
+    into nulls. Each line is tagged `"event": "missing_code"` so the replay
+    consumer skips it when rebuilding the rule set.
+
+    Args:
+        logger: configured replay logger.
+        rule: the HarmonizationRule that produced the target column.
+        dataset: dataset identifier (the `source dataset` name).
+        hits: iterable of (row_index, value, label) tuples.
+    """
+    source = rule.sources[0] if rule.sources else None
+    for row_index, value, label in hits:
+        record = {
+            "event": "missing_code",
+            "dataset": dataset,
+            "target": rule.target,
+            "source": source,
+            "row": row_index,
+            "value": value,
+            "label": label,
+        }
+        logger.info(json.dumps(record))

--- a/src/harmonization_framework/utils/transformations.py
+++ b/src/harmonization_framework/utils/transformations.py
@@ -19,14 +19,22 @@ def replay(log_file: str, datasets: Dict[str, pd.DataFrame]):
     """
     Replay a log file against the provided datasets.
 
-    Each line of the log is a JSON event with {"dataset", "action"}, where
+    Each replayable line is a JSON event with {"dataset", "action"}, where
     action is a serialized HarmonizationRule. Rules are grouped by dataset and
     applied in log order via a per-dataset RuleSet.
+
+    The log may also contain non-replayable audit events (e.g. per-value
+    "missing_code" hits). These are skipped here: only events whose `event` key
+    is "rule" build the rule set. Lines with no `event` key are treated as
+    "rule" for backward-compatibility with logs written before the discriminator
+    was introduced.
     """
     events: Dict[str, List[dict]] = {}
     with open(log_file, "r") as f:
         for line in f:
             event = json.loads(line.strip())
+            if event.get("event", "rule") != "rule":
+                continue
             events.setdefault(event["dataset"], []).append(event)
 
     logger = rlog.configure_logger(3, "replay_" + log_file)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -24,7 +24,14 @@ def test_cli_harmonize_csv_multiple_rules(tmp_path):
             "sources": ["a"],
             "target": "b",
             "operations": [
-                {"operation": "enum_to_enum", "mapping": {"1": 10, "2": 20}, "strict": True}
+                {
+                    "operation": "enum_to_enum",
+                    # `a` is read from CSV as integers (pandas type inference), so
+                    # the mapping is keyed by ints. The entry-list form keeps them
+                    # as JSON numbers through serialization.
+                    "mapping": [{"from": 1, "to": 10}, {"from": 2, "to": 20}],
+                    "strict": True,
+                }
             ],
         }
     ]

--- a/tests/test_multi_source.py
+++ b/tests/test_multi_source.py
@@ -108,7 +108,11 @@ def test_cli_runs_multi_source_rule(tmp_path):
                 },
                 {
                     "operation": "enum_to_enum",
-                    "mapping": {"0": "baseline", "1": "follow_up", "2": "screening"},
+                    "mapping": [
+                        {"from": "0", "to": "baseline"},
+                        {"from": "1", "to": "follow_up"},
+                        {"from": "2", "to": "screening"},
+                    ],
                     "strict": True,
                 },
             ],

--- a/tests/test_null_handling.py
+++ b/tests/test_null_handling.py
@@ -21,6 +21,7 @@ from harmonization_framework.primitives import (
     ConvertUnits,
     FormatNumber,
     MapEach,
+    MissingCode,
     NormalizeText,
     Offset,
     Reduce,
@@ -97,6 +98,21 @@ def test_handle_null_passes_through_and_calls_underlying_only_for_non_null():
 @pytest.mark.parametrize("null", NULLS)
 def test_scale_passes_null_through(null):
     assert _is_same_null(Scale(2.0).transform(null), null)
+
+
+@pytest.mark.parametrize("null", NULLS)
+def test_missing_code_passes_genuine_null_through(null):
+    # MissingCode is not @handle_null (its null check is explicit), but a real
+    # null must never be treated as a code: it passes through unchanged.
+    primitive = MissingCode({-999: "not_measured"})
+    assert _is_same_null(primitive.transform(null), null)
+
+
+def test_missing_code_nulls_only_declared_codes():
+    primitive = MissingCode({-999: "not_measured"})
+    assert primitive.transform(-999) is None      # the code -> real null
+    assert primitive.transform(-998) == -998      # neighbour value untouched
+    assert primitive.transform(0) == 0            # zero is not a code
 
 
 @pytest.mark.parametrize("null", NULLS)

--- a/tests/test_primitives_serialization.py
+++ b/tests/test_primitives_serialization.py
@@ -9,6 +9,7 @@ from harmonization_framework.primitives import (
     EnumToEnum,
     FormatNumber,
     MapEach,
+    MissingCode,
     NormalizeBoolean,
     NormalizeText,
     Offset,
@@ -544,3 +545,54 @@ def test_map_each_rejects_non_list():
 def test_map_each_empty_operations_is_identity():
     primitive = MapEach([])
     assert primitive.transform([1, 2, 3]) == [1, 2, 3]
+
+
+def test_missing_code_serialization_and_transform():
+    primitive = MissingCode({-999: "not_measured", -1: "refused"})
+    payload = primitive.to_dict()
+
+    assert payload["operation"] == "missing_code"
+    assert payload["codes"] == {-999: "not_measured", -1: "refused"}
+
+    roundtrip = MissingCode.from_serialization(payload)
+    assert roundtrip.to_dict() == payload
+
+    # A declared code becomes a real null; other values pass through unchanged.
+    assert primitive.transform(-999) is None
+    assert primitive.transform(-1) is None
+    assert primitive.transform(150.0) == 150.0
+    assert primitive.transform([-999, 150.0, -1]) == [None, 150.0, None]
+
+
+def test_missing_code_list_form_defaults_label():
+    primitive = MissingCode([-999, -1])
+    payload = primitive.to_dict()
+
+    # A bare list normalises to the default label, and serialises as a dict.
+    assert payload["codes"] == {-999: "missing", -1: "missing"}
+    roundtrip = MissingCode.from_serialization(payload)
+    assert roundtrip.to_dict() == payload
+    assert roundtrip.transform(-999) is None
+
+
+def test_missing_code_numeric_keys_survive_json_roundtrip():
+    # JSON object keys are always strings; an int code must coerce back to int
+    # so it still matches a numeric input after a rules.json round-trip.
+    import json
+
+    primitive = MissingCode({-999: "not_measured"})
+    reloaded = MissingCode.from_serialization(json.loads(json.dumps(primitive.to_dict())))
+
+    assert list(reloaded.codes.keys()) == [-999]
+    assert reloaded.transform(-999) is None
+    assert reloaded.transform(-999.0) is None
+    assert reloaded.transform(150.0) == 150.0
+
+
+def test_missing_code_rejects_empty_and_bad_type():
+    with pytest.raises(ValueError):
+        MissingCode([])
+    with pytest.raises(ValueError):
+        MissingCode({})
+    with pytest.raises(TypeError):
+        MissingCode("nope")

--- a/tests/test_primitives_serialization.py
+++ b/tests/test_primitives_serialization.py
@@ -1,3 +1,5 @@
+import json
+
 import pytest
 
 from harmonization_framework.primitives import (
@@ -109,7 +111,8 @@ def test_enum_to_enum_serialization_and_transform():
     payload = primitive.to_dict()
 
     assert payload["operation"] == "enum_to_enum"
-    assert payload["mapping"] == {1: 10, 2: 20}
+    # Mapping serializes as a list of {from, to} entries, preserving key type.
+    assert payload["mapping"] == [{"from": 1, "to": 10}, {"from": 2, "to": 20}]
     assert payload["strict"] is False
 
     roundtrip = EnumToEnum.from_serialization(payload)
@@ -121,7 +124,7 @@ def test_enum_to_enum_serialization_and_transform():
 def test_enum_to_enum_string_mapping_roundtrip():
     payload = {
         "operation": "enum_to_enum",
-        "mapping": {"BL": "baseline", "FU": "follow_up"},
+        "mapping": [{"from": "BL", "to": "baseline"}, {"from": "FU", "to": "follow_up"}],
         "default": "unknown",
         "strict": False,
     }
@@ -132,16 +135,17 @@ def test_enum_to_enum_string_mapping_roundtrip():
     assert roundtrip.transform(["BL", "FU", "ZZ"]) == ["baseline", "follow_up", "unknown"]
 
 
-def test_enum_to_enum_string_keys_preserved():
-    payload = {
-        "operation": "enum_to_enum",
-        "mapping": {"1": "one", "2": "two"},
-        "strict": False,
-    }
+def test_enum_to_enum_int_keys_survive_json_roundtrip():
+    # The entry-list form keeps integer keys as JSON numbers, so an int-keyed
+    # map mapping to STRING labels still matches integer inputs after a full
+    # json.dumps/loads cycle — the gotcha that string-keyed JSON objects caused.
+    primitive = EnumToEnum({0: "research", 1: "clinical"}, default="other")
+    reloaded = EnumToEnum.from_serialization(json.loads(json.dumps(primitive.to_dict())))
 
-    roundtrip = EnumToEnum.from_serialization(payload)
-    assert roundtrip.to_dict() == payload
-    assert roundtrip.transform("1") == "one"
+    assert list(reloaded.mapping.keys()) == [0, 1]
+    assert reloaded.transform(0) == "research"
+    assert reloaded.transform(1) == "clinical"
+    assert reloaded.transform(2) == "other"
 
 
 def test_enum_to_enum_default_for_missing_value():
@@ -552,7 +556,11 @@ def test_missing_code_serialization_and_transform():
     payload = primitive.to_dict()
 
     assert payload["operation"] == "missing_code"
-    assert payload["codes"] == {-999: "not_measured", -1: "refused"}
+    # Codes serialize as a list of {code, label} entries, preserving code type.
+    assert payload["codes"] == [
+        {"code": -999, "label": "not_measured"},
+        {"code": -1, "label": "refused"},
+    ]
 
     roundtrip = MissingCode.from_serialization(payload)
     assert roundtrip.to_dict() == payload
@@ -568,18 +576,19 @@ def test_missing_code_list_form_defaults_label():
     primitive = MissingCode([-999, -1])
     payload = primitive.to_dict()
 
-    # A bare list normalises to the default label, and serialises as a dict.
-    assert payload["codes"] == {-999: "missing", -1: "missing"}
+    # A bare list normalises to the default label, and serialises as entries.
+    assert payload["codes"] == [
+        {"code": -999, "label": "missing"},
+        {"code": -1, "label": "missing"},
+    ]
     roundtrip = MissingCode.from_serialization(payload)
     assert roundtrip.to_dict() == payload
     assert roundtrip.transform(-999) is None
 
 
 def test_missing_code_numeric_keys_survive_json_roundtrip():
-    # JSON object keys are always strings; an int code must coerce back to int
-    # so it still matches a numeric input after a rules.json round-trip.
-    import json
-
+    # The entry-list form keeps a numeric code as a JSON number, so it still
+    # matches a numeric input after a full rules.json round-trip.
     primitive = MissingCode({-999: "not_measured"})
     reloaded = MissingCode.from_serialization(json.loads(json.dumps(primitive.to_dict())))
 

--- a/tests/test_replay_logger.py
+++ b/tests/test_replay_logger.py
@@ -1,6 +1,14 @@
+import json
 import logging
 
+import pandas as pd
+
+from harmonization_framework.harmonization_rule import HarmonizationRule
+from harmonization_framework.harmonize import harmonize_dataset
+from harmonization_framework.primitives import MissingCode, Scale
 from harmonization_framework.replay_log import replay_logger as rlog
+from harmonization_framework.rule_registry import RuleSet
+from harmonization_framework.utils.transformations import replay
 
 
 def test_configure_logger_clears_handlers(tmp_path):
@@ -18,3 +26,71 @@ def test_configure_logger_clears_handlers(tmp_path):
     handler = logger2.handlers[0]
     assert isinstance(handler, logging.FileHandler)
     assert handler.baseFilename == str(log2)
+
+
+def _read_log_events(log_path):
+    with open(log_path) as f:
+        return [json.loads(line) for line in f if line.strip()]
+
+
+def test_missing_code_hits_are_logged_per_row(tmp_path):
+    df = pd.DataFrame({"reading_lb": [150.0, 160.0, -999.0, 175.5]})
+    rules = RuleSet()
+    rules.add_rule(
+        HarmonizationRule(
+            sources=["reading_lb"],
+            target="reading_kg",
+            transformation=[MissingCode({-999: "not_measured"}), Scale(0.45359237)],
+        )
+    )
+
+    log_path = tmp_path / "replay.log"
+    logger = rlog.configure_logger(3, str(log_path))
+    out = harmonize_dataset(df, rules, "messy", logger)
+    for handler in logger.handlers:
+        handler.flush()
+
+    # The code was nulled, so the scaled output is missing for that row.
+    assert pd.isna(out["reading_kg"].iloc[2])
+
+    events = _read_log_events(log_path)
+    rule_events = [e for e in events if e.get("event") == "rule"]
+    hit_events = [e for e in events if e.get("event") == "missing_code"]
+
+    assert len(rule_events) == 1
+    assert len(hit_events) == 1
+    hit = hit_events[0]
+    assert hit["dataset"] == "messy"
+    assert hit["target"] == "reading_kg"
+    assert hit["source"] == "reading_lb"
+    assert hit["row"] == 2
+    assert hit["value"] == -999.0
+    assert hit["label"] == "not_measured"
+
+
+def test_replay_skips_missing_code_events(tmp_path, monkeypatch):
+    df = pd.DataFrame({"reading_lb": [150.0, -999.0]})
+    rules = RuleSet()
+    rules.add_rule(
+        HarmonizationRule(
+            sources=["reading_lb"],
+            target="reading_kg",
+            transformation=[MissingCode({-999: "not_measured"}), Scale(0.45359237)],
+        )
+    )
+
+    # replay() prefixes the log filename with "replay_", so run from a scratch
+    # cwd with a relative name to keep that derived path valid.
+    monkeypatch.chdir(tmp_path)
+    logger = rlog.configure_logger(3, "replay.log")
+    expected = harmonize_dataset(df, rules, "messy", logger)
+    for handler in logger.handlers:
+        handler.flush()
+
+    # The log contains a missing_code line; replay must skip it (not try to
+    # rebuild a rule from it) and still reproduce the rule result.
+    results = replay("replay.log", {"messy": df})
+    replayed = results["messy"]
+
+    assert replayed["reading_kg"].iloc[0] == expected["reading_kg"].iloc[0]
+    assert pd.isna(replayed["reading_kg"].iloc[1])


### PR DESCRIPTION
## Summary

Two related changes to missing-data handling and mapping serialization.

### 1. `MissingCode` primitive (+ per-value replay logging)
A new `missing_code` primitive that turns declared missing-value codes (e.g. numeric `-999`) into real nulls while passing every other value — including genuine nulls — through unchanged. This is the identity-preserving null map that `EnumToEnum` cannot express (an unmapped value always returns `default`, so `EnumToEnum` can't null one code without nulling the column).

- Each code carries a label (e.g. `"not_measured"`). The label isn't written to the output (a null has no room for a reason); instead the harmonize engine reports each nulled cell — value, label, row index — to the replay log. Codes + labels are also recorded in `rules.json`.
- `transformations.py::replay` skips non-rule log events (per-value hits aren't replayable); rule events are tagged `"event": "rule"`, and a missing key defaults to `"rule"` for older logs.

### 2. Lossless mapping serialization (fixes a silent int-key bug)
JSON object keys are always strings, so an `EnumToEnum` keyed by integers (e.g. the index from `Reduce(ONEHOT)`) round-tripped through `rules.json` with string keys and then missed every lookup, silently falling through to `default`. The old defence was a coercion heuristic that only restored int keys when keys *and* values were both int-like — which failed for the common int-key → string-label case.

Fixed at the root: `EnumToEnum.mapping` now serializes as a list of `{"from","to"}` entries, and `MissingCode.codes` as `{"code","label"}` entries. Each key sits in a value position and keeps its native JSON type, so no coercion is needed (the `is_int_like`/`is_float_like` code is removed). Matches `Bin`'s existing list-of-objects style.

**No backward compatibility** — only the new entry form is read (framework not widely used yet).

## Testing
- Full suite passes (177 tests), including new JSON round-trip guards that an int-keyed `EnumToEnum` and a numeric-code `MissingCode` still match integer inputs after `dumps`/`loads` — now guaranteed by the format, not by coercion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)