### PR TITLE
Support YAML rule files alongside JSON

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,5 +13,6 @@ pydantic==2.10.6
 pydantic-core==2.27.2
 pyproject-toml==0.1.0
 python-dateutil==2.9.0
+pyyaml==6.0.2
 setuptools==75.8.2
 pytest

--- a/src/harmonization_framework/cli.py
+++ b/src/harmonization_framework/cli.py
@@ -94,7 +94,8 @@ def build_parser() -> argparse.ArgumentParser:
         "--rules",
         required=True,
         action="append",
-        help="Path to a rules JSON file. Can be provided multiple times.",
+        help="Path to a rules file (JSON, or YAML if the path ends in "
+        ".yaml/.yml). Can be provided multiple times.",
     )
     parser.add_argument("--input", required=True, help="Input CSV/TSV file.")
     parser.add_argument("--output", required=True, help="Output CSV/TSV file.")

--- a/src/harmonization_framework/rule_registry.py
+++ b/src/harmonization_framework/rule_registry.py
@@ -2,9 +2,32 @@ import json
 import logging
 from typing import Iterable, List
 
+import yaml
+
 from .harmonization_rule import HarmonizationRule
 
 logger = logging.getLogger(__name__)
+
+
+def _is_yaml(path: str) -> bool:
+    """Return True if `path` names a YAML file (.yaml / .yml)."""
+    return path.lower().endswith((".yaml", ".yml"))
+
+
+def _blank_line_between_rules(dumped: str) -> str:
+    """
+    Insert a blank line before each top-level rule in dumped YAML (except the
+    first), so a multi-rule file is easy to scan. Top-level rules are the list
+    items that begin at column 0 with "- "; continuation lines are indented and
+    left untouched. Purely cosmetic — the parsed content is unchanged.
+    """
+    lines = dumped.split("\n")
+    out = []
+    for i, line in enumerate(lines):
+        if i > 0 and line.startswith("- "):
+            out.append("")
+        out.append(line)
+    return "\n".join(out)
 
 
 class RuleSet:
@@ -62,15 +85,31 @@ class RuleSet:
 
     def save(self, output: str = "rules.json") -> None:
         """
-        Serialize rules to a JSON file as a flat array.
+        Serialize rules to a flat array file.
+
+        The format is chosen by the file extension: `.yaml`/`.yml` writes YAML,
+        anything else writes JSON. Both encode the same structure (a list of
+        rule dicts), so the choice is purely about which on-disk form you want.
+
+        YAML is emitted with `default_flow_style=None`: scalar-only collections
+        (a `sources` list, a `{from, to}` mapping entry) render inline, while the
+        surrounding structure stays in block form. A blank line is inserted
+        between top-level rules so the file is easy to scan. This keeps the rule
+        skeleton readable while compacting the leaf items.
         """
         payload = [rule.serialize() for rule in self._rules]
         with open(output, "w") as out:
-            json.dump(payload, out, indent=2)
+            if _is_yaml(output):
+                dumped = yaml.safe_dump(payload, sort_keys=False, default_flow_style=None)
+                out.write(_blank_line_between_rules(dumped))
+            else:
+                json.dump(payload, out, indent=2)
 
     def load(self, rule_file: str, clean: bool = False) -> None:
         """
-        Load rules from a JSON file, optionally clearing existing rules first.
+        Load rules from a JSON or YAML file, optionally clearing existing rules
+        first. The format is chosen by the file extension (`.yaml`/`.yml` for
+        YAML, otherwise JSON).
 
         Accepts both the new flat-array schema and the legacy nested
         {source: {target: rule}} schema for migration convenience.
@@ -79,7 +118,10 @@ class RuleSet:
             self.clean()
 
         with open(rule_file, "r") as rf:
-            data = json.load(rf)
+            if _is_yaml(rule_file):
+                data = yaml.safe_load(rf)
+            else:
+                data = json.load(rf)
 
         for rule_payload in _iter_rule_payloads(data):
             self.add_rule(HarmonizationRule.from_serialization(rule_payload))

--- a/tests/test_yaml_rules.py
+++ b/tests/test_yaml_rules.py
@@ -1,0 +1,134 @@
+"""
+YAML rule files behave identically to JSON.
+
+`RuleSet.save`/`load` choose the format by file extension (.yaml/.yml -> YAML,
+otherwise JSON). YAML and JSON encode the same flat array of rule dicts, so a
+rule set round-trips through either form and produces identical harmonized
+output. YAML also preserves integer mapping keys natively (a property the
+example suite relies on for one-hot index -> label mappings).
+"""
+
+import csv
+
+import pandas as pd
+
+from harmonization_framework import cli
+from harmonization_framework.harmonization_rule import HarmonizationRule
+from harmonization_framework.harmonize import harmonize_dataset
+from harmonization_framework.primitives import EnumToEnum, Round
+from harmonization_framework.rule_registry import RuleSet
+
+
+def _sample_ruleset() -> RuleSet:
+    rules = RuleSet()
+    # An int-keyed enum mapping to string labels — the case that must keep its
+    # key type through serialization — plus a second primitive for variety.
+    rules.add_rule(
+        HarmonizationRule(
+            sources=["code"],
+            target="label",
+            transformation=[EnumToEnum({1: "one", 2: "two"}, default="other", strict=False)],
+        )
+    )
+    rules.add_rule(
+        HarmonizationRule(
+            sources=["measure"],
+            target="measure_rounded",
+            transformation=[Round(1)],
+        )
+    )
+    return rules
+
+
+def test_yaml_roundtrip_preserves_int_keys(tmp_path):
+    path = tmp_path / "rules.yaml"
+    _sample_ruleset().save(str(path))
+
+    loaded = RuleSet()
+    loaded.load(str(path), clean=True)
+
+    df = pd.DataFrame({"code": [1, 2, 3], "measure": [1.23, 4.56, 7.89]})
+    out = harmonize_dataset(df, loaded, "t")
+
+    # Integer keys survived YAML: 1 -> one, 2 -> two, 3 (unmapped) -> other.
+    assert out["label"].tolist() == ["one", "two", "other"]
+    assert out["measure_rounded"].tolist() == [1.2, 4.6, 7.9]
+
+
+def test_json_and_yaml_produce_identical_output(tmp_path):
+    json_path = tmp_path / "rules.json"
+    yaml_path = tmp_path / "rules.yaml"
+    _sample_ruleset().save(str(json_path))
+    _sample_ruleset().save(str(yaml_path))
+
+    df = pd.DataFrame({"code": [1, 2, 3], "measure": [1.23, 4.56, 7.89]})
+
+    from_json = RuleSet()
+    from_json.load(str(json_path), clean=True)
+    from_yaml = RuleSet()
+    from_yaml.load(str(yaml_path), clean=True)
+
+    out_json = harmonize_dataset(df, from_json, "t")
+    out_yaml = harmonize_dataset(df, from_yaml, "t")
+    pd.testing.assert_frame_equal(out_json, out_yaml)
+
+
+def test_extension_detection(tmp_path):
+    # .yml is YAML too.
+    yml_path = tmp_path / "rules.yml"
+    _sample_ruleset().save(str(yml_path))
+    text = yml_path.read_text()
+    assert "operation: enum_to_enum" in text  # YAML, not JSON braces
+
+    loaded = RuleSet()
+    loaded.load(str(yml_path), clean=True)
+    assert len(loaded) == 2
+
+    # An unknown extension defaults to JSON.
+    json_default = tmp_path / "rules.rules"
+    _sample_ruleset().save(str(json_default))
+    assert json_default.read_text().lstrip().startswith("[")  # JSON array
+
+
+def test_yaml_uses_hybrid_flow_for_leaf_collections(tmp_path):
+    # default_flow_style=None renders scalar-only collections inline (a sources
+    # list, a {from, to} mapping entry) while keeping the surrounding structure
+    # in block form. This is a readability choice; it must still round-trip.
+    path = tmp_path / "rules.yaml"
+    _sample_ruleset().save(str(path))
+    text = path.read_text()
+
+    assert "sources: [code]" in text          # scalar list rendered inline
+    assert "- {from: 1, to: one}" in text      # mapping entry rendered inline
+    assert "operations:" in text               # outer structure stays block
+
+    # A blank line separates top-level rules (the second rule is preceded by one).
+    assert "\n\n- sources: [measure]" in text  # second rule's source is `measure`
+
+    loaded = RuleSet()
+    loaded.load(str(path), clean=True)
+    df = pd.DataFrame({"code": [1, 2, 3], "measure": [1.23, 4.56, 7.89]})
+    assert harmonize_dataset(df, loaded, "t")["label"].tolist() == ["one", "two", "other"]
+
+
+def test_cli_accepts_yaml_rules(tmp_path):
+    rules = _sample_ruleset()
+    yaml_path = tmp_path / "rules.yaml"
+    rules.save(str(yaml_path))
+
+    input_path = tmp_path / "input.csv"
+    with input_path.open("w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=["code", "measure"])
+        writer.writeheader()
+        writer.writerows([{"code": "1", "measure": "1.23"}, {"code": "2", "measure": "4.56"}])
+
+    output_path = tmp_path / "output.csv"
+    cli.main([
+        "--rules", str(yaml_path),
+        "--input", str(input_path),
+        "--output", str(output_path),
+    ])
+
+    with output_path.open() as f:
+        out_rows = list(csv.DictReader(f))
+    assert [r["label"] for r in out_rows] == ["one", "two"]


### PR DESCRIPTION
## Summary

Adds YAML as a supported serialization for rule files, alongside the existing JSON. `RuleSet.save`/`load` choose the format by **file extension**: `.yaml`/`.yml` read and write YAML, anything else JSON. Both encode the same flat array of rule dicts, so a rule set round-trips through either form, and the CLI's `--rules` accepts a YAML path automatically (it loads via `RuleSet.load`).

## Why

YAML is more readable for hand-authoring and reviewing rules, and it preserves **integer mapping keys natively** — unlike a JSON object, whose keys are always strings. (An int-keyed `enum_to_enum` map, e.g. a one-hot index → label, therefore matches integer inputs correctly after a YAML round-trip.)

## Details

- `rule_registry.py`: `_is_yaml` / `_blank_line_between_rules` helpers; `save`/`load` branch on extension.
- YAML is emitted with `default_flow_style=None` — scalar-only collections (a `sources` list, a `{from, to}` mapping entry) render inline while the surrounding structure stays block — and a blank line separates top-level rules, so multi-rule files stay readable.
- `requirements.txt`: add `pyyaml`.
- `cli.py`: `--rules` help text notes JSON or YAML.

## Testing

`tests/test_yaml_rules.py` covers: round-trip including int keys, JSON/YAML output equivalence on harmonized data, the hybrid-flow layout, extension detection (`.yml`/`.json`/unknown→JSON), and a CLI run with `rules.yaml`. Full suite: 182 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)