### PR TITLE
Declare runtime dependencies so the CLI installs with pipx

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ pip install -r requirements.txt
 pip install .
 ```
 
+To use only the command-line tools (`harmonize` and `harmonization-sidecar`) without setting up a development environment, install with [pipx](https://pipx.pypa.io/), which puts the commands on your PATH in an isolated environment:
+
+```bash
+pipx install git+https://github.com/bmir-radx/harmonization-framework.git
+```
+
 ## Usage
 
 We recommend using the harmonization framework in an interactive Python environment like a Jupyter notebook. A demonstration is provided in `demo/integration.ipynb`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,14 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Operating System :: OS Independent",
 ]
+dependencies = [
+    "pandas>=2.2.3",
+    "pint>=0.24.3",
+    "pyyaml>=6.0.2",
+    "fastapi>=0.115.6",
+    "uvicorn>=0.30.6",
+    "pydantic>=2.10.6",
+]
 
 [project.scripts]
 harmonization-sidecar = "harmonization_framework.api.sidecar:main"


### PR DESCRIPTION
## Summary
- `pyproject.toml` declared no `dependencies` — they lived only in `requirements.txt`, which pipx (and plain `pip install .` into a fresh venv) never reads, so the installed `harmonize` entry point crashed on import
- Declare the runtime set verified against actual imports in `src`: `pandas`, `pint`, `pyyaml`, `fastapi`, `uvicorn`, `pydantic`
- Use `>=` bounds rather than `==` pins: exact pins stay in `requirements.txt` for the dev environment, while `==` pins in package metadata force failing source builds on Pythons newer than the pinned wheels (e.g. `pydantic-core` 2.27.2 has no CPython 3.14 wheels)
- Document `pipx install git+https://github.com/bmir-radx/harmonization-framework.git` in the README installation section

## Test plan
- `pipx install <repo>` on Python 3.14.6: install succeeds, `harmonize` runs a YAML rule end to end with correct output, `harmonization-sidecar` starts and `/health/` responds OK
- `pytest tests` — 199 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)