### PR TITLE
Add --validate flag to check rules files without harmonizing

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,18 @@ Notes:
 - Restrict outputs with `--targets nih_age,nih_sex`.
 - `--dataset-name` sets the dataset name used for metadata columns (defaults to the input file name).
 
+#### Validating rules files
+
+Check rules files (JSON or YAML) without running a harmonization by adding `--validate`; `--input` and `--output` are not required:
+
+```bash
+harmonize --validate \
+  --rules rules/radx_up_rules.json \
+  --rules rules/radx_rad_rules.yaml
+```
+
+Each file is checked independently and every problem is reported — syntax errors, missing or malformed `sources`/`target`/`operations`, unknown operations, invalid operation settings, duplicate targets within a file, and empty files. Prints `OK` or `INVALID` per file and exits with a non-zero status if any file has problems, so it can gate a CI step.
+
 ## Serialization Format
 
 Harmonization rules and primitives serialize to JSON-friendly dictionaries with a consistent schema. A rules file is a flat array of rule dicts, written as JSON or YAML depending on the file extension (`.yaml`/`.yml` for YAML, otherwise JSON) — both encode the same structure.

--- a/src/harmonization_framework/cli.py
+++ b/src/harmonization_framework/cli.py
@@ -6,7 +6,7 @@ import pandas as pd
 
 from .harmonize import harmonize_dataset
 from .harmonization_rule import HarmonizationRule
-from .rule_registry import RuleSet
+from .rule_registry import RuleSet, validate_rules_file
 
 
 def _split_list(values: Sequence[str]) -> List[str]:
@@ -97,8 +97,14 @@ def build_parser() -> argparse.ArgumentParser:
         help="Path to a rules file (JSON, or YAML if the path ends in "
         ".yaml/.yml). Can be provided multiple times.",
     )
-    parser.add_argument("--input", required=True, help="Input CSV/TSV file.")
-    parser.add_argument("--output", required=True, help="Output CSV/TSV file.")
+    parser.add_argument("--input", help="Input CSV/TSV file.")
+    parser.add_argument("--output", help="Output CSV/TSV file.")
+    parser.add_argument(
+        "--validate",
+        action="store_true",
+        help="Validate the rules files and exit without harmonizing; "
+        "--input/--output are not required.",
+    )
     parser.add_argument(
         "--targets",
         action="append",
@@ -124,9 +130,32 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+def _validate_rules(rule_paths: Iterable[str]) -> int:
+    # Validate each rules file independently and report every problem found.
+    # Returns a process exit code: 0 if all files are valid, 1 otherwise.
+    exit_code = 0
+    for path in rule_paths:
+        problems = validate_rules_file(path)
+        if problems:
+            exit_code = 1
+            print(f"{path}: INVALID")
+            for problem in problems:
+                print(f"  {problem}")
+        else:
+            print(f"{path}: OK")
+    return exit_code
+
+
 def main(argv: Sequence[str] | None = None) -> None:
     parser = build_parser()
     args = parser.parse_args(argv)
+
+    if args.validate:
+        raise SystemExit(_validate_rules(args.rules))
+
+    if not args.input or not args.output:
+        parser.error("--input and --output are required unless --validate is given.")
+        return
 
     try:
         rules = _load_rules(args.rules)

--- a/src/harmonization_framework/rule_registry.py
+++ b/src/harmonization_framework/rule_registry.py
@@ -143,3 +143,84 @@ def _iter_rule_payloads(data):
                 yield rule_payload
         return
     raise ValueError(f"Unrecognized rules file format: expected list or dict, got {type(data).__name__}")
+
+
+def validate_rules_file(rule_file: str) -> List[str]:
+    """
+    Validate a JSON or YAML rules file without applying it.
+
+    Returns a list of human-readable problems; an empty list means the file is
+    valid. Unlike `load`, which raises on the first bad rule, this checks every
+    rule and reports all problems found. The format is chosen by file extension,
+    the same way `load` chooses it.
+    """
+    try:
+        with open(rule_file, "r") as rf:
+            if _is_yaml(rule_file):
+                data = yaml.safe_load(rf)
+            else:
+                data = json.load(rf)
+    except FileNotFoundError:
+        return ["file not found"]
+    except yaml.YAMLError as exc:
+        return [f"invalid YAML: {exc}"]
+    except json.JSONDecodeError as exc:
+        return [f"invalid JSON: {exc}"]
+
+    try:
+        payloads = list(_iter_rule_payloads(data))
+    except ValueError as exc:
+        return [str(exc)]
+
+    if not payloads:
+        return ["file contains no rules"]
+
+    errors: List[str] = []
+    targets_seen = {}
+    for index, payload in enumerate(payloads):
+        errors.extend(_validate_rule_payload(index, payload, targets_seen))
+    return errors
+
+
+def _validate_rule_payload(index, payload, targets_seen) -> List[str]:
+    """
+    Validate one rule payload, returning its problems. `targets_seen` maps
+    target -> rule number for duplicate detection and is updated in place.
+    """
+    from .primitives.factory import deserialize_operation
+
+    if not isinstance(payload, dict):
+        return [f"rule {index + 1}: expected a dict, got {type(payload).__name__}"]
+
+    target = payload.get("target")
+    where = f"rule {index + 1} (target {target!r})" if isinstance(target, str) else f"rule {index + 1}"
+
+    errors = []
+    if not isinstance(target, str) or not target:
+        errors.append(f"{where}: 'target' must be a non-empty string")
+    elif target in targets_seen:
+        errors.append(
+            f"{where}: duplicate target {target!r} (also produced by rule {targets_seen[target]}); "
+            f"only one rule per target survives loading"
+        )
+    else:
+        targets_seen[target] = index + 1
+
+    sources = payload.get("sources", [payload["source"]] if "source" in payload else None)
+    if not isinstance(sources, list) or not sources or not all(isinstance(s, str) and s for s in sources):
+        errors.append(f"{where}: 'sources' must be a non-empty list of column names (or legacy 'source' string)")
+
+    operations = payload.get("operations")
+    if not isinstance(operations, list):
+        errors.append(f"{where}: 'operations' must be a list of operation dicts")
+        return errors
+
+    for op_index, op in enumerate(operations):
+        if not isinstance(op, dict) or "operation" not in op:
+            errors.append(f"{where}: operation {op_index + 1}: expected a dict with an 'operation' key")
+            continue
+        try:
+            deserialize_operation(op)
+        except Exception as exc:
+            errors.append(f"{where}: operation {op_index + 1} ({op['operation']!r}): {exc}")
+    return errors

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1,0 +1,187 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from harmonization_framework import cli
+from harmonization_framework.rule_registry import validate_rules_file
+
+
+VALID_RULE = {
+    "sources": ["height_in"],
+    "target": "height_cm",
+    "operations": [
+        {"operation": "convert_units", "source_unit": "inch", "target_unit": "cm"},
+        {"operation": "round", "precision": 1},
+    ],
+}
+
+
+def _write_json(path: Path, payload) -> None:
+    path.write_text(json.dumps(payload, indent=2) + "\n")
+
+
+def test_validate_valid_json_file(tmp_path):
+    rules_path = tmp_path / "rules.json"
+    _write_json(rules_path, [VALID_RULE])
+    assert validate_rules_file(str(rules_path)) == []
+
+
+def test_validate_valid_yaml_file(tmp_path):
+    rules_path = tmp_path / "rules.yaml"
+    rules_path.write_text(
+        "- sources: [height_in]\n"
+        "  target: height_cm\n"
+        "  operations:\n"
+        "  - {operation: convert_units, source_unit: inch, target_unit: cm}\n"
+        "  - {operation: round, precision: 1}\n"
+    )
+    assert validate_rules_file(str(rules_path)) == []
+
+
+def test_validate_legacy_source_key(tmp_path):
+    rules_path = tmp_path / "rules.json"
+    _write_json(
+        rules_path,
+        [{"source": "a", "target": "b", "operations": [{"operation": "do_nothing"}]}],
+    )
+    assert validate_rules_file(str(rules_path)) == []
+
+
+def test_validate_missing_file(tmp_path):
+    problems = validate_rules_file(str(tmp_path / "nope.json"))
+    assert problems == ["file not found"]
+
+
+def test_validate_json_syntax_error(tmp_path):
+    rules_path = tmp_path / "rules.json"
+    rules_path.write_text("[{,]")
+    problems = validate_rules_file(str(rules_path))
+    assert len(problems) == 1
+    assert problems[0].startswith("invalid JSON")
+
+
+def test_validate_yaml_syntax_error(tmp_path):
+    rules_path = tmp_path / "rules.yaml"
+    rules_path.write_text("- sources: [a\n  target: b\n")
+    problems = validate_rules_file(str(rules_path))
+    assert len(problems) == 1
+    assert problems[0].startswith("invalid YAML")
+
+
+def test_validate_empty_file(tmp_path):
+    rules_path = tmp_path / "rules.json"
+    _write_json(rules_path, [])
+    assert validate_rules_file(str(rules_path)) == ["file contains no rules"]
+
+
+def test_validate_unknown_operation(tmp_path):
+    rules_path = tmp_path / "rules.json"
+    _write_json(
+        rules_path,
+        [
+            {
+                "sources": ["a"],
+                "target": "b",
+                "operations": [{"operation": "frobnicate"}],
+            }
+        ],
+    )
+    problems = validate_rules_file(str(rules_path))
+    assert len(problems) == 1
+    assert "'frobnicate'" in problems[0]
+    assert "Unknown operation" in problems[0]
+
+
+def test_validate_bad_operation_settings(tmp_path):
+    # A known operation with an invalid setting (bad regex) is reported.
+    rules_path = tmp_path / "rules.json"
+    _write_json(
+        rules_path,
+        [
+            {
+                "sources": ["a"],
+                "target": "b",
+                "operations": [{"operation": "extract_regex", "expression": "("}],
+            }
+        ],
+    )
+    problems = validate_rules_file(str(rules_path))
+    assert len(problems) == 1
+    assert "operation 1 ('extract_regex')" in problems[0]
+
+
+def test_validate_missing_target_and_sources(tmp_path):
+    rules_path = tmp_path / "rules.json"
+    _write_json(rules_path, [{"operations": []}])
+    problems = validate_rules_file(str(rules_path))
+    assert any("'target'" in p for p in problems)
+    assert any("'sources'" in p for p in problems)
+
+
+def test_validate_duplicate_target(tmp_path):
+    rules_path = tmp_path / "rules.json"
+    _write_json(rules_path, [VALID_RULE, VALID_RULE])
+    problems = validate_rules_file(str(rules_path))
+    assert len(problems) == 1
+    assert "duplicate target 'height_cm'" in problems[0]
+    assert "rule 1" in problems[0]
+
+
+def test_validate_reports_all_problems(tmp_path):
+    # Validation keeps going after the first bad rule.
+    rules_path = tmp_path / "rules.json"
+    _write_json(
+        rules_path,
+        [
+            {"sources": ["a"], "target": "b", "operations": [{"operation": "nope1"}]},
+            {"sources": ["c"], "target": "d", "operations": [{"operation": "nope2"}]},
+        ],
+    )
+    problems = validate_rules_file(str(rules_path))
+    assert len(problems) == 2
+
+
+def test_cli_validate_ok(tmp_path, capsys):
+    rules_path = tmp_path / "rules.json"
+    _write_json(rules_path, [VALID_RULE])
+    with pytest.raises(SystemExit) as excinfo:
+        cli.main(["--validate", "--rules", str(rules_path)])
+    assert excinfo.value.code == 0
+    assert f"{rules_path}: OK" in capsys.readouterr().out
+
+
+def test_cli_validate_invalid_exits_nonzero(tmp_path, capsys):
+    rules_path = tmp_path / "rules.json"
+    _write_json(
+        rules_path,
+        [{"sources": ["a"], "target": "b", "operations": [{"operation": "frobnicate"}]}],
+    )
+    with pytest.raises(SystemExit) as excinfo:
+        cli.main(["--validate", "--rules", str(rules_path)])
+    assert excinfo.value.code == 1
+    out = capsys.readouterr().out
+    assert f"{rules_path}: INVALID" in out
+    assert "frobnicate" in out
+
+
+def test_cli_validate_multiple_files(tmp_path, capsys):
+    good = tmp_path / "good.json"
+    bad = tmp_path / "bad.json"
+    _write_json(good, [VALID_RULE])
+    _write_json(bad, [{"target": "b"}])
+    with pytest.raises(SystemExit) as excinfo:
+        cli.main(["--validate", "--rules", str(good), "--rules", str(bad)])
+    assert excinfo.value.code == 1
+    out = capsys.readouterr().out
+    assert f"{good}: OK" in out
+    assert f"{bad}: INVALID" in out
+
+
+def test_cli_harmonize_still_requires_input_and_output(tmp_path, capsys):
+    rules_path = tmp_path / "rules.json"
+    _write_json(rules_path, [VALID_RULE])
+    with pytest.raises(SystemExit) as excinfo:
+        cli.main(["--rules", str(rules_path)])
+    assert excinfo.value.code == 2
+    assert "--input and --output are required" in capsys.readouterr().err


### PR DESCRIPTION
## Summary
- `harmonize --validate --rules a.json --rules b.yaml` validates each rules file (JSON or YAML by extension, same as loading) and exits non-zero if any file has problems, so it can gate a CI step; `--input`/`--output` are not required in this mode (still enforced otherwise)
- New `validate_rules_file` in `rule_registry.py`: unlike `RuleSet.load`, which raises on the first bad rule, it checks every rule and operation and reports all problems — syntax errors, malformed `sources`/`target`/`operations`, unknown operations, invalid operation settings (validated by actual deserialization, so nested `case`/`coalesce`/`map_each` children are covered), duplicate targets within a file, and empty files
- Documented in the README under "Validating rules files"

Sample output:
```
bad_rules.yaml: INVALID
  rule 1 (target 'b'): operation 1 ('frobnicate'): Unknown operation: frobnicate
  rule 2: 'target' must be a non-empty string
  rule 2: operation 1 ('extract_regex'): Invalid regex pattern: '('
```

## Test plan
- 16 new tests in `tests/test_validate.py` covering both syntaxes, legacy `source` key, every error class, multi-file exit codes, and that plain harmonization still requires `--input`/`--output`
- `pytest tests` — 215 passed
- Verified from a pipx install: valid file exits 0, broken file exits 1 with all problems listed

🤖 Generated with [Claude Code](https://claude.com/claude-code)