### PR TITLE
Bump setuptools to 78.1.1 to fix GHSA-5rjg-fvgr-3xxf

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,5 +14,5 @@ pydantic-core==2.27.2
 pyproject-toml==0.1.0
 python-dateutil==2.9.0
 pyyaml==6.0.2
-setuptools==75.8.2
+setuptools==78.1.1
 pytest


### PR DESCRIPTION
## Summary
- Bump `setuptools` from 75.8.2 to 78.1.1 in `requirements.txt`
- Resolves Dependabot alert #1 (high severity): path traversal in `PackageIndex.download` allowing arbitrary file writes ([GHSA-5rjg-fvgr-3xxf](https://github.com/advisories/GHSA-5rjg-fvgr-3xxf)), fixed in 78.1.1

## Test plan
- Installed setuptools 78.1.1 into the dev venv; `pytest tests` — 215 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)