### PR TITLE
Add --format json to --list-operations; hint on unknown operations in validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Notes:
 - By default only target columns are written. Add `--include-metadata` to include `source dataset` and `original_id`.
 - Restrict outputs with `--targets nih_age,nih_sex`.
 - `--dataset-name` sets the dataset name used for metadata columns (defaults to the input file name).
-- `harmonize --list-operations` prints the available primitive operations with a short description of each.
+- `harmonize --list-operations` prints the available primitive operations with a short description of each. Add `--format json` for a machine-readable listing that includes the full help text per operation (with authoring examples for `case`/`coalesce`) — useful for tools and AI agents that write rules files.
 
 #### Validating rules files
 
@@ -58,7 +58,7 @@ harmonize --validate \
   --rules rules/radx_rad_rules.yaml
 ```
 
-Each file is checked independently and every problem is reported — syntax errors, missing or malformed `sources`/`target`/`operations`, unknown operations, invalid operation settings, duplicate targets within a file, and empty files. Prints `OK` or `INVALID` per file and exits with a non-zero status if any file has problems, so it can gate a CI step.
+Each file is checked independently and every problem is reported — syntax errors, missing or malformed `sources`/`target`/`operations`, unknown operations, invalid operation settings, duplicate targets within a file, and empty files. An unknown operation gets a did-you-mean suggestion and a pointer to `--list-operations`. Prints `OK` or `INVALID` per file and exits with a non-zero status if any file has problems, so it can gate a CI step.
 
 ## Serialization Format
 

--- a/src/harmonization_framework/cli.py
+++ b/src/harmonization_framework/cli.py
@@ -1,5 +1,6 @@
 import argparse
 import inspect
+import json
 import os
 import textwrap
 from typing import Iterable, List, Sequence
@@ -136,12 +137,32 @@ def build_parser() -> argparse.ArgumentParser:
         help="List the available primitive operations with a short "
         "description of each, then exit.",
     )
+    parser.add_argument(
+        "--format",
+        choices=["text", "json"],
+        default="text",
+        help="Output format for --list-operations. 'json' emits the full "
+        "help text per operation, for consumption by tools and AI agents.",
+    )
     return parser
 
 
-def _list_operations() -> None:
-    # Print each operation name with the first paragraph of its class
-    # docstring, so the listing always matches the implemented primitives.
+def _list_operations(output_format: str = "text") -> None:
+    # Derive the listing from each class docstring, so it always matches the
+    # implemented primitives. The json form carries the FULL docstring: for
+    # case/coalesce that includes complete authoring examples, which is what
+    # a tool or AI agent needs to write a valid operation, not just name it.
+    if output_format == "json":
+        entries = [
+            {
+                "operation": name,
+                "summary": " ".join((inspect.getdoc(cls) or "").split("\n\n")[0].split()),
+                "help": inspect.getdoc(cls) or "",
+            }
+            for name, cls in sorted(OPERATION_CLASSES.items())
+        ]
+        print(json.dumps(entries, indent=2))
+        return
     for name in sorted(OPERATION_CLASSES):
         doc = inspect.getdoc(OPERATION_CLASSES[name])
         summary = " ".join(doc.split("\n\n")[0].split()) if doc else "(no description)"
@@ -154,6 +175,7 @@ def _validate_rules(rule_paths: Iterable[str]) -> int:
     # Validate each rules file independently and report every problem found.
     # Returns a process exit code: 0 if all files are valid, 1 otherwise.
     exit_code = 0
+    saw_unknown_operation = False
     for path in rule_paths:
         problems = validate_rules_file(path)
         if problems:
@@ -161,8 +183,13 @@ def _validate_rules(rule_paths: Iterable[str]) -> int:
             print(f"{path}: INVALID")
             for problem in problems:
                 print(f"  {problem}")
+            saw_unknown_operation = saw_unknown_operation or any(
+                "unknown operation" in problem for problem in problems
+            )
         else:
             print(f"{path}: OK")
+    if saw_unknown_operation:
+        print("hint: run 'harmonize --list-operations' to see the available operations")
     return exit_code
 
 
@@ -171,7 +198,7 @@ def main(argv: Sequence[str] | None = None) -> None:
     args = parser.parse_args(argv)
 
     if args.list_operations:
-        _list_operations()
+        _list_operations(args.format)
         return
 
     if not args.rules:

--- a/src/harmonization_framework/rule_registry.py
+++ b/src/harmonization_framework/rule_registry.py
@@ -1,3 +1,4 @@
+import difflib
 import json
 import logging
 from typing import Iterable, List
@@ -187,7 +188,7 @@ def _validate_rule_payload(index, payload, targets_seen) -> List[str]:
     Validate one rule payload, returning its problems. `targets_seen` maps
     target -> rule number for duplicate detection and is updated in place.
     """
-    from .primitives.factory import deserialize_operation
+    from .primitives.factory import OPERATION_CLASSES, deserialize_operation
 
     if not isinstance(payload, dict):
         return [f"rule {index + 1}: expected a dict, got {type(payload).__name__}"]
@@ -219,8 +220,14 @@ def _validate_rule_payload(index, payload, targets_seen) -> List[str]:
         if not isinstance(op, dict) or "operation" not in op:
             errors.append(f"{where}: operation {op_index + 1}: expected a dict with an 'operation' key")
             continue
+        name = op["operation"]
+        if name not in OPERATION_CLASSES:
+            close = difflib.get_close_matches(str(name), list(OPERATION_CLASSES), n=1)
+            did_you_mean = f" (did you mean {close[0]!r}?)" if close else ""
+            errors.append(f"{where}: operation {op_index + 1}: unknown operation {name!r}{did_you_mean}")
+            continue
         try:
             deserialize_operation(op)
         except Exception as exc:
-            errors.append(f"{where}: operation {op_index + 1} ({op['operation']!r}): {exc}")
+            errors.append(f"{where}: operation {op_index + 1} ({name!r}): {exc}")
     return errors

--- a/tests/test_list_operations.py
+++ b/tests/test_list_operations.py
@@ -23,6 +23,21 @@ def test_cli_list_operations(capsys):
     assert "Convert numeric values between units" in out
 
 
+def test_cli_list_operations_json(capsys):
+    import json
+
+    cli.main(["--list-operations", "--format", "json"])
+    entries = json.loads(capsys.readouterr().out)
+    assert {entry["operation"] for entry in entries} == set(OPERATION_CLASSES)
+    for entry in entries:
+        assert entry["summary"]
+        assert entry["help"]
+    # The full help for the combinators includes their authoring examples.
+    case_entry = next(e for e in entries if e["operation"] == "case")
+    assert "selector" in case_entry["help"]
+    assert "branches" in case_entry["help"]
+
+
 def test_cli_list_operations_ignores_other_args(capsys):
     # The list is printed even if other flags are supplied.
     cli.main(["--list-operations", "--on-missing", "warn"])

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -90,7 +90,24 @@ def test_validate_unknown_operation(tmp_path):
     problems = validate_rules_file(str(rules_path))
     assert len(problems) == 1
     assert "'frobnicate'" in problems[0]
-    assert "Unknown operation" in problems[0]
+    assert "unknown operation" in problems[0]
+
+
+def test_validate_unknown_operation_suggests_close_match(tmp_path):
+    rules_path = tmp_path / "rules.json"
+    _write_json(
+        rules_path,
+        [
+            {
+                "sources": ["a"],
+                "target": "b",
+                "operations": [{"operation": "normalize_bool"}],
+            }
+        ],
+    )
+    problems = validate_rules_file(str(rules_path))
+    assert len(problems) == 1
+    assert "did you mean 'normalize_boolean'?" in problems[0]
 
 
 def test_validate_bad_operation_settings(tmp_path):
@@ -163,6 +180,15 @@ def test_cli_validate_invalid_exits_nonzero(tmp_path, capsys):
     out = capsys.readouterr().out
     assert f"{rules_path}: INVALID" in out
     assert "frobnicate" in out
+    assert "hint: run 'harmonize --list-operations'" in out
+
+
+def test_cli_validate_no_hint_without_unknown_operation(tmp_path, capsys):
+    rules_path = tmp_path / "rules.json"
+    _write_json(rules_path, [{"target": "b"}])
+    with pytest.raises(SystemExit):
+        cli.main(["--validate", "--rules", str(rules_path)])
+    assert "--list-operations" not in capsys.readouterr().out
 
 
 def test_cli_validate_multiple_files(tmp_path, capsys):


### PR DESCRIPTION
## Summary
- `harmonize --list-operations --format json` emits a machine-readable listing: `[{operation, summary, help}]` where `help` is the full class docstring — for `case`/`coalesce` that includes complete authoring examples, so tools and AI agents that write rules files get authoring guidance, not just names
- Validation detects unknown operation names explicitly and adds a did-you-mean suggestion (`unknown operation 'normalize_bool' (did you mean 'normalize_boolean'?)`)
- When any unknown operation is reported, the validate output ends with `hint: run 'harmonize --list-operations' to see the available operations`

Sample validate output:
```
bad_rules.yaml: INVALID
  rule 1 (target 'b'): operation 1: unknown operation 'frobnicate' (did you mean 'truncate'?)
  rule 2: 'target' must be a non-empty string
  rule 2: operation 1 ('extract_regex'): Invalid regex pattern: '('
hint: run 'harmonize --list-operations' to see the available operations
```

## Test plan
- New tests: JSON listing covers the full registry with non-empty summary/help and authoring examples present for `case`; did-you-mean suggestion; hint shown on unknown operations and absent otherwise
- `pytest tests` — 224 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)