### PR TITLE
Bump version and tag automatically on merge to main

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,0 +1,73 @@
+name: Bump Version
+
+# After each merge to main, bump the version in pyproject.toml, commit the
+# bump, and tag the release vX.Y.Z. The bump size comes from the merged PR's
+# labels: release:major or release:minor, defaulting to a patch bump when
+# neither is present. Label a PR release:skip to not bump at all.
+#
+# The bump commit is pushed with the default GITHUB_TOKEN, whose pushes do
+# not trigger workflows, so this cannot re-trigger itself.
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    if: github.actor != 'github-actions[bot]'
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Determine bump level from merged PR labels
+        id: level
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          labels=$(gh api "repos/${{ github.repository }}/commits/${{ github.sha }}/pulls" \
+            --jq '[.[0].labels[].name] | join(",")' 2>/dev/null || echo "")
+          echo "PR labels: ${labels:-none}"
+          level=patch
+          case ",$labels," in *,release:minor,*) level=minor ;; esac
+          case ",$labels," in *,release:major,*) level=major ;; esac
+          case ",$labels," in *,release:skip,*)  level=skip  ;; esac
+          echo "level=$level" >> "$GITHUB_OUTPUT"
+          echo "Bump level: $level"
+
+      - name: Bump version, commit, and tag
+        if: steps.level.outputs.level != 'skip'
+        run: |
+          NEW_VERSION=$(python3 - "${{ steps.level.outputs.level }}" <<'PY'
+          import re, sys
+
+          level = sys.argv[1]
+          text = open("pyproject.toml").read()
+          m = re.search(r'^version = "(\d+)\.(\d+)\.(\d+)"$', text, re.M)
+          if m is None:
+              sys.exit("Could not find a version = \"X.Y.Z\" line in pyproject.toml")
+          major, minor, patch = map(int, m.groups())
+          if level == "major":
+              major, minor, patch = major + 1, 0, 0
+          elif level == "minor":
+              minor, patch = minor + 1, 0
+          else:
+              patch += 1
+          new = f"{major}.{minor}.{patch}"
+          with open("pyproject.toml", "w") as f:
+              f.write(text[:m.start()] + f'version = "{new}"' + text[m.end():])
+          print(new)
+          PY
+          )
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add pyproject.toml
+          git commit -m "chore: bump version to ${NEW_VERSION}"
+          git tag "v${NEW_VERSION}"
+          git push origin main --follow-tags

--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ To use only the command-line tools (`harmonize` and `harmonization-sidecar`) wit
 pipx install git+https://github.com/bmir-radx/harmonization-framework.git
 ```
 
+To pin a specific release, append a tag (e.g. `...framework.git@v0.1.0`). To pick up the latest changes later, run `pipx reinstall harmonization-framework` — for packages installed from a git URL this is more reliable than `pipx upgrade`.
+
+## Releases
+
+Every pull request merged to `main` automatically bumps the version in `pyproject.toml` and tags the release (`vX.Y.Z`) via the Bump Version workflow. By default the patch version is bumped; label the PR `release:minor` or `release:major` for a larger bump, or `release:skip` to not release at all.
+
 ## Usage
 
 The harmonization framework in an interactive Python environment like a Jupyter notebook. A demonstration is provided in `demo/integration.ipynb` or it can be used as a CLI tool.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "harmonization-framework"
-version = "0.0.1"
+version = "0.1.0"
 authors = [
   { name="jkyu", email="jkyu@stanford.edu" },
 ]


### PR DESCRIPTION
## Summary
- Adds a `Bump Version` workflow that fires on each push to `main` (i.e. after every PR merge): bumps the version in `pyproject.toml`, commits, and tags `vX.Y.Z`
- Bump size comes from the merged PR's labels: patch by default, `release:minor` / `release:major` for larger bumps, `release:skip` to skip releasing (labels created on the repo)
- Self-trigger safe: pushes made with the default `GITHUB_TOKEN` don't trigger workflows, plus an actor guard
- Starts the version at 0.1.0 (acknowledging the recent feature work); v0.1.0 will be tagged on the merge commit
- README: documents the release flow, pinning pipx installs to a tag, and `pipx reinstall` for git-URL installs

This PR carries `release:skip` so the setup merge itself doesn't bump 0.1.0 to 0.1.1.

## Test plan
- Workflow YAML validated; bump script tested locally at all three levels from 0.1.0 (→ 0.1.1 / 0.2.0 / 1.0.0)
- After merge: confirm the workflow run honors `release:skip`; the next regular PR merge will exercise the actual bump+tag path

🤖 Generated with [Claude Code](https://claude.com/claude-code)