### PR TITLE
Remove pytest from build-system requires

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.0", "pytest>=7.3.1"]
+requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
## Summary
- `build-system.requires` listed `pytest`, which is a test dependency, not a build requirement; building only needs setuptools
- Also serves as the first unlabeled merge through the new Bump Version workflow — expected to bump 0.1.0 → 0.1.1 and tag v0.1.1

## Test plan
- `pip wheel . --no-deps` builds the wheel successfully without pytest in build requires
- After merge: verify the version bump commit and v0.1.1 tag land on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)