### PR TITLE
Push the release tag explicitly in the bump workflow

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -70,4 +70,6 @@ jobs:
           git add pyproject.toml
           git commit -m "chore: bump version to ${NEW_VERSION}"
           git tag "v${NEW_VERSION}"
-          git push origin main --follow-tags
+          # Push the branch and the tag explicitly: --follow-tags only pushes
+          # annotated tags and would silently skip this lightweight one.
+          git push origin main "v${NEW_VERSION}"


### PR DESCRIPTION
## Summary
- `git push --follow-tags` only pushes annotated tags, so the lightweight `vX.Y.Z` tag created by the bump workflow was silently never pushed (v0.1.1 had to be pushed by hand)
- Push the tag ref explicitly alongside `main` instead

## Test plan
- This PR is deliberately unlabeled: its merge should bump 0.1.1 → 0.1.2 AND push the v0.1.2 tag, verifying the fixed path end to end

🤖 Generated with [Claude Code](https://claude.com/claude-code)